### PR TITLE
meta: add issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,51 @@
+name: Report a Technical/Visual Issue on the Node.js API Docs 
+description: 'Is something not working as expected? Did you encounter a glitch or a bug with the docs?'
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting an issue you've found with Node.js' API docs.
+        Please fill in the template below. If unsure about something, just do as best
+        as you're able. If you are reporting a visual glitch, it will be much easier
+        for us to fix it when you attach a screenshot as well.
+  - type: input
+    attributes:
+      label: 'URL:'
+      description: The URL of the page you are reporting an issue on.
+      placeholder: https://nodejs.org/api/
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: 'Browser Name:'
+      description: What kind of browser are you using?
+      placeholder: Chrome
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: 'Browser Version:'
+      description: What version of browser are you using?
+      placeholder: '103.0.5060.134'
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: 'Operating System:'
+      description: What kind of operation system are you using
+        (Write it in full, with version number)?
+      placeholder: 'Windows 10, 21H2, 19044.1826'
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 'How to reproduce the issue:'
+      placeholder: |
+        1. What I did.
+        2. What I expected to happen.
+        3. What I actually got.
+        4. If possible, images or videos are welcome.
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -1,0 +1,20 @@
+name: Suggest a new feature or improvement for Node.js' docs.
+description: 'Do you have an idea or a suggestion and you want to share?'
+labels: [feature request]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You have an idea how to improve the docs? That's awesome!
+        Before submitting, please have a look at the existing issues if there's already
+        something related to your suggestion.
+  - type: textarea
+    attributes:
+      label: 'Enter your suggestions in details:'
+      placeholder: |
+        1. What I expected to happen.
+        2. Your reason (if possible, images or videos are welcome).
+        3. What I plan to do (Optional but better).
+    validations:
+      required: true
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--
+Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
+-->
+
+## Description
+
+<!-- Write a brief description of the changes introduced by this PR -->
+
+## Validation
+
+<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
+
+## Related Issues
+
+<!--
+  Link to the issue that is fixed by this PR (if there is one)
+  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
+-->
+
+### Check List
+
+<!--
+ATTENTION
+Please follow this check list to ensure that you've followed all items before opening this PR
+You can check the items by adding an `x` between the brackets, like this: `[x]`
+-->
+
+- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
+- [ ] I've covered new added functionality with unit tests if necessary.
+


### PR DESCRIPTION
Pretty much just pulled the ones from the website repo and modified them where needed

Note: we don't have COLLABORATORS.md yet but I still kept the link there for when we do. Excluded any npm commands until we know what they'll be for tests, etc.

Partially takes care of #13 