### PR TITLE
feat: introduce release metadata to generators

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,30 +1,54 @@
 #!/usr/bin/env node
 
-import { argv } from 'node:process';
 import { resolve } from 'node:path';
+import { argv } from 'node:process';
 
 import { Command, Option } from 'commander';
 
+import { coerce } from 'semver';
+import { DOC_NODE_CHANGELOG_URL, DOC_NODE_VERSION } from '../src/constants.mjs';
 import createGenerator from '../src/generators.mjs';
+import generators from '../src/generators/index.mjs';
 import createLoader from '../src/loader.mjs';
 import createParser from '../src/parser.mjs';
-import generators from '../src/generators/index.mjs';
+import createNodeReleases from '../src/releases.mjs';
+
+const availableGenerators = Object.keys(generators);
 
 const program = new Command();
 
 program
   .name('api-docs-tooling')
   .description('CLI tool to generate API documentation of a Node.js project.')
-  .requiredOption(
-    '-i, --input <patterns...>',
-    'Specify input file patterns using glob syntax'
+  .addOption(
+    new Option(
+      '-i, --input <patterns>',
+      'Specify input file patterns using glob syntax'
+    ).makeOptionMandatory()
   )
-  .requiredOption('-o, --output <path>', 'Specify the output directory path')
+  .addOption(
+    new Option(
+      '-o, --output <path>',
+      'Specify the relative or absolute output directory'
+    ).makeOptionMandatory()
+  )
+  .addOption(
+    new Option(
+      '-v, --version <semver>',
+      'Specify the target version of Node.js, semver compliant'
+    ).default(DOC_NODE_VERSION)
+  )
+  .addOption(
+    new Option(
+      '-c, --changelog <url>',
+      'Specify the path (file: or https://) to the CHANGELOG.md file'
+    ).default(DOC_NODE_CHANGELOG_URL)
+  )
   .addOption(
     new Option(
       '-t, --target [mode...]',
-      'Set the processing target mode'
-    ).choices(Object.keys(generators))
+      'Set the processing target modes'
+    ).choices(availableGenerators)
   )
   .parse(argv);
 
@@ -34,13 +58,15 @@ program
  * @typedef {Object} Options
  * @property {Array<string>|string} input Specifies the glob/path for input files.
  * @property {string} output Specifies the directory where output files will be saved.
- * @property {Target} target Specifies the generator target mode.
+ * @property {Target[]} target Specifies the generator target mode.
+ * @property {string} version Specifies the target Node.js version.
+ * @property {string} changelog Specifies the path to the Node.js CHANGELOG.md file
  *
  * @name ProgramOptions
  * @type {Options}
  * @description The return type for values sent to the program from the CLI.
  */
-const { input, output, target } = program.opts();
+const { input, output, target = [], version, changelog } = program.opts();
 
 const { loadFiles } = createLoader();
 const { parseApiDocs } = createParser();
@@ -51,7 +77,16 @@ const parsedApiDocs = await parseApiDocs(apiDocFiles);
 
 const { runGenerators } = createGenerator(parsedApiDocs);
 
+// Retrieves Node.js release metadata from a given Node.js version and CHANGELOG.md file
+const { getAllMajors } = createNodeReleases(changelog);
+
 await runGenerators({
+  // A list of target modes for the API docs parser
   generators: target,
+  // Resolved `output` path to be used
   output: resolve(output),
+  // Resolved SemVer of current Node.js version
+  version: coerce(version),
+  // A list of all Node.js major versions with LTS status
+  releases: await getAllMajors(),
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@ import eslintConfigPrettier from 'eslint-config-prettier';
 import globals from 'globals';
 
 export default [
-  { languageOptions: { globals: globals.browser } },
+  { languageOptions: { globals: globals.node } },
   // Visit https://eslint.org/docs/latest/rules to learn more about these rules
   pluginJs.configs.recommended,
   eslintConfigPrettier,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "glob": "^11.0.0",
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.0",
+        "semver": "^7.6.3",
         "unist-builder": "^4.0.0",
         "unist-util-find-after": "^5.0.0",
         "unist-util-position": "^5.0.0",
@@ -2984,6 +2985,18 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -19,11 +19,12 @@
     "prettier": "3.3.3"
   },
   "dependencies": {
-    "github-slugger": "^2.0.0",
     "commander": "^12.1.0",
+    "github-slugger": "^2.0.0",
     "glob": "^11.0.0",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.0",
+    "semver": "^7.6.3",
     "unist-builder": "^4.0.0",
     "unist-util-find-after": "^5.0.0",
     "unist-util-position": "^5.0.0",

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,7 +1,11 @@
 'use strict';
 
-// This is the base-path of API docs within the https://nodejs.org Website
-export const DOC_WEB_BASE_PATH = '/docs/';
+// The current running version of Node.js (Environment)
+export const DOC_NODE_VERSION = process.version;
+
+// This is the Node.js CHANGELOG to be consumed to generate a list of all major Node.js versions
+export const DOC_NODE_CHANGELOG_URL =
+  'https://raw.githubusercontent.com/nodejs/node/HEAD/CHANGELOG.md';
 
 // This is the base URL of the MDN Web documentation
 export const DOC_MDN_BASE_URL = 'https://developer.mozilla.org/en-US/docs/Web/';

--- a/src/generators.mjs
+++ b/src/generators.mjs
@@ -36,7 +36,7 @@ const createGenerator = input => {
    *
    * @param {import('./generators/types.d.ts').GeneratorOptions} options The options for the generator runtime
    */
-  const runGenerators = async ({ output, generators }) => {
+  const runGenerators = async ({ generators, ...extra }) => {
     // Note that this method is blocking, and will only execute one generator per-time
     // but it ensures all dependencies are resolved, and that multiple bottom-level generators
     // can reuse the already parsed content from the top-level/dependency generators
@@ -46,7 +46,7 @@ const createGenerator = input => {
       // If the generator dependency has not yet been resolved, we resolve
       // the dependency first before running the current generator
       if (dependsOn && dependsOn in cachedGenerators === false) {
-        await runGenerators({ output, generators: [dependsOn] });
+        await runGenerators({ ...extra, generators: [dependsOn] });
       }
 
       // Ensures that the dependency output gets resolved before we run the current
@@ -54,7 +54,7 @@ const createGenerator = input => {
       const dependencyOutput = await cachedGenerators[dependsOn];
 
       // Adds the current generator execution Promise to the cache
-      cachedGenerators[generatorName] = generate(dependencyOutput, { output });
+      cachedGenerators[generatorName] = generate(dependencyOutput, extra);
     }
 
     // Returns the value of the last generator of the current pipeline

--- a/src/generators/json-simple/index.mjs
+++ b/src/generators/json-simple/index.mjs
@@ -25,6 +25,8 @@ export default {
   dependsOn: 'ast',
 
   async generate(input, options) {
+    console.log(options);
+
     // This simply grabs all the different files and stringifies them
     const stringifiedContent = JSON.stringify(input, null, 2);
 

--- a/src/generators/json-simple/index.mjs
+++ b/src/generators/json-simple/index.mjs
@@ -25,7 +25,6 @@ export default {
   dependsOn: 'ast',
 
   async generate(input, options) {
-    console.log(options);
 
     // This simply grabs all the different files and stringifies them
     const stringifiedContent = JSON.stringify(input, null, 2);

--- a/src/generators/types.d.ts
+++ b/src/generators/types.d.ts
@@ -1,4 +1,6 @@
+import type { SemVer } from 'semver';
 import type availableGenerators from './index.mjs';
+import { ApiDocReleaseEntry } from '../types';
 
 // All available generators as an inferable type, to allow Generator interfaces
 // to be type complete and runtime friendly within `runGenerators`
@@ -11,11 +13,18 @@ export interface GeneratorOptions {
   // This parameter accepts globs but when passed to generators will contain
   // the already resolved absolute path to the output folder
   output: string;
+
   // A list of generators to be used in the API doc generation process;
   // This is considered a "sorted" list of generators, in the sense that
   // if the last entry of this list contains a generated value, we will return
   // the value of the last generator in the list, if any.
-  generators: (keyof AvailableGenerators)[];
+  generators: Array<keyof AvailableGenerators>;
+
+  // Target Node.js version for the generation of the API docs
+  version: SemVer;
+
+  // A list of all Node.js major versions and their respective release information
+  releases: Array<ApiDocReleaseEntry>;
 }
 
 export interface GeneratorMetadata<I extends any, O extends any> {

--- a/src/releases.mjs
+++ b/src/releases.mjs
@@ -31,7 +31,7 @@ const getChangelogFromFileSystem = async changelogUrl =>
  * This creates an utility to retrieve the Node.js major release metadata
  * purely out from the Node.js CHANGELOG.md file
  *
- * @param {string} changelogPath The gien URL to the Node.js CHANGELOG.md file
+ * @param {string} changelogPath The given URL to the Node.js CHANGELOG.md file
  */
 const createNodeReleases = changelogPath => {
   const changelogUrl = new URL(changelogPath);

--- a/src/releases.mjs
+++ b/src/releases.mjs
@@ -1,0 +1,64 @@
+'use strict';
+
+import { readFile } from 'node:fs/promises';
+import { coerce } from 'semver';
+
+// A ReGeX for retrieving Node.js version headers from the CHANGELOG.md
+const NODE_VERSIONS_REGEX = /\* \[Node\.js ([0-9.]+)\]\S+ (.*)\r?\n/g;
+
+// A ReGeX for checking if a Node.js version is an LTS release
+const NODE_LTS_VERSION_REGEX = /Long Term Support/i;
+
+/**
+ * Retrieves the Node.js CHANGELOG.md via a Network Request,
+ * used when a non-file protocol is provided
+ *
+ * @param {URL} changelogUrl The URL to the CHANGELOG.md raw content
+ */
+const getChangelogFromNetwork = async changelogUrl =>
+  fetch(changelogUrl).then(response => response.text());
+
+/**
+ * Retrieves the Node.js CHANGELOG.md via the File System,
+ * used when a file protocol is provided
+ *
+ * @param {URL} changelogUrl The File Path to the CHANGELOG.md file
+ */
+const getChangelogFromFileSystem = async changelogUrl =>
+  readFile(changelogUrl, 'utf-8');
+
+/**
+ * This creates an utility to retrieve the Node.js major release metadata
+ * purely out from the Node.js CHANGELOG.md file
+ *
+ * @param {string} changelogPath The gien URL to the Node.js CHANGELOG.md file
+ */
+const createNodeReleases = changelogPath => {
+  const changelogUrl = new URL(changelogPath);
+
+  const changelogStrategy =
+    changelogUrl.protocol === 'https:'
+      ? getChangelogFromNetwork(changelogUrl)
+      : getChangelogFromFileSystem(changelogUrl);
+
+  /**
+   * Retrieves all Node.js major versions from the provided CHANGELOG.md file
+   * and returns an array of objects containing the version and LTS status.
+   *
+   * @returns {Promise<Array<import('./types.d.ts').ApiDocReleaseEntry>>}
+   */
+  const getAllMajors = async () => {
+    const changelog = await changelogStrategy;
+
+    const nodeMajors = Array.from(changelog.matchAll(NODE_VERSIONS_REGEX));
+
+    return nodeMajors.map(match => ({
+      version: coerce(match[1]),
+      isLts: NODE_LTS_VERSION_REGEX.test(match[2]),
+    }));
+  };
+
+  return { getAllMajors };
+};
+
+export default createNodeReleases;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,5 @@
-import { Parent, Node } from 'unist';
+import type { SemVer } from 'semver';
+import type { Parent, Node } from 'unist';
 
 // String serialization of the AST tree
 // @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#tojson_behavior
@@ -66,4 +67,9 @@ export interface ApiDocMetadataEntry {
   stability: WithJSON<Parent, StabilityIndexMetadataEntry> | undefined;
   // The subtree containing all Nodes of the API doc entry
   content: WithJSON<Parent, string>;
+}
+
+export interface ApiDocReleaseEntry {
+  version: SemVer;
+  isLts: boolean;
 }


### PR DESCRIPTION
This PR introduces the ability for the API docs tooling to retrieve the current running/target Node.js version and all major versions from the CHANGELOG.md file; this is important since relative version metadata is necessary during the doc build process.

In the future, when the proper React/MDX generators are created, this information will be used for the Navigation of different Node.js versions and + for knowing what version the API docs are targeting.

This will also be used for the legacy API doc tooling.