### PR TITLE
refactor: applied bug fixes and code refactor from #55

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,8 +3,12 @@ import eslintConfigPrettier from 'eslint-config-prettier';
 import globals from 'globals';
 
 export default [
-  { languageOptions: { globals: globals.node } },
-  // Visit https://eslint.org/docs/latest/rules to learn more about these rules
+  // @see https://eslint.org/docs/latest/use/configure/configuration-files#specifying-files-and-ignores
+  {
+    files: ['src/**/*.mjs'],
+    languageOptions: { globals: globals.node },
+  },
+  // @see https://eslint.org/docs/latest/rules to learn more about these rules
   pluginJs.configs.recommended,
   eslintConfigPrettier,
 ];

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -19,15 +19,6 @@ export const DOC_MDN_BASE_URL_JS_PRIMITIVES = `${DOC_MDN_BASE_URL_JS}Data_struct
 // This is the base URL for the MDN JavaScript global objects documentation
 export const DOC_MDN_BASE_URL_JS_GLOBALS = `${DOC_MDN_BASE_URL_JS}Reference/Global_Objects/`;
 
-// These are YAML keys from the Markdown YAML Metadata that should always be arrays
-export const DOC_API_YAML_KEYS_ARRAYS = [
-  'added',
-  'napiVersion',
-  'deprecated',
-  'removed',
-  'introduced_in',
-];
-
 // These are YAML keys from the Markdown YAML metadata that should be
 // removed and appended to the `update` key
 export const DOC_API_YAML_KEYS_UPDATE = [
@@ -72,6 +63,16 @@ export const DOC_API_HEADING_TYPES = [
     regex: /^(?:Class property: +)?`?([A-Z]\w+(?:\.[A-Z]\w+)*\.\w+)`?$/i,
   },
 ];
+
+// This is a mapping for the `API` updates within the Markdown content and their respective
+// content that should be mapping into `changes` property for better mapping on HTML
+export const DOC_API_UPDATE_MAPPING = {
+  added: 'Added in',
+  removed: 'Removed in',
+  deprecated: 'Deprecated since',
+  introduced_in: 'Introduced in',
+  napiVersion: 'N-API Version',
+};
 
 // This is a mapping for types within the Markdown content and their respective
 // JavaScript primitive types within the MDN JavaScript docs

--- a/src/generators.mjs
+++ b/src/generators.mjs
@@ -3,7 +3,6 @@
 import availableGenerators from './generators/index.mjs';
 
 /**
- * @typedef {import('./types.d.ts').ApiDocMetadataEntry} ApiDocMetadataEntry Local type alias for the API doc metadata entry
  * @typedef {{ ast: import('./generators/types.d.ts').GeneratorMetadata<ApiDocMetadataEntry, ApiDocMetadataEntry>}} AstGenerator The AST "generator" is a facade for the AST tree and it isn't really a generator
  * @typedef {import('./generators/types.d.ts').AvailableGenerators & AstGenerator} AllGenerators A complete set of the available generators, including the AST one
  *

--- a/src/generators/json-simple/index.mjs
+++ b/src/generators/json-simple/index.mjs
@@ -10,7 +10,7 @@ import { join } from 'node:path';
  * This generator is a top-level generator, and it takes the raw AST tree of the API doc files
  * and returns a stringified JSON version of the API docs.
  *
- * @typedef {import('../../types.d.ts').ApiDocMetadataEntry[]} Input
+ * @typedef {Array<ApiDocMetadataEntry>} Input
  *
  * @type {import('../types.d.ts').GeneratorMetadata<Input, string>}
  */
@@ -25,7 +25,6 @@ export default {
   dependsOn: 'ast',
 
   async generate(input, options) {
-
     // This simply grabs all the different files and stringifies them
     const stringifiedContent = JSON.stringify(input, null, 2);
 

--- a/src/generators/types.d.ts
+++ b/src/generators/types.d.ts
@@ -1,6 +1,6 @@
 import type { SemVer } from 'semver';
 import type availableGenerators from './index.mjs';
-import { ApiDocReleaseEntry } from '../types';
+import type { ApiDocReleaseEntry } from '../types';
 
 // All available generators as an inferable type, to allow Generator interfaces
 // to be type complete and runtime friendly within `runGenerators`

--- a/src/loader.mjs
+++ b/src/loader.mjs
@@ -1,7 +1,7 @@
 'use strict';
 
-import { extname } from 'node:path';
 import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
 
 import { globSync } from 'glob';
 import { VFile } from 'vfile';

--- a/src/metadata.mjs
+++ b/src/metadata.mjs
@@ -1,10 +1,13 @@
 'use strict';
 
+import { u as createTree } from 'unist-builder';
+
+import { compare } from 'semver';
+
+import { DOC_API_UPDATE_MAPPING } from './constants.mjs';
+import { coerceSemVer } from './utils/generators.mjs';
+
 /**
- * @typedef {import('./types.d.ts').ApiDocMetadataEntry} ApiDocMetadataEntry Local type alias for the API doc metadata entry
- * @typedef {import('./types.d.ts').ApiDocRawMetadataEntry} ApiDocRawMetadataEntry Local type alias for the API doc raw metadata entry
- * @typedef {import('./types.d.ts').HeadingMetadataEntry} HeadingMetadataEntry Local type alias for the heading metadata entry
- *
  * This method allows us to handle creation of Metadata entries
  * within the current scope of API docs being parsed
  *
@@ -14,6 +17,29 @@
  * @param {InstanceType<typeof import('github-slugger').default>} slugger A GitHub Slugger
  */
 const createMetadata = slugger => {
+  /**
+   * Maps `updates` into `changes` format, merges them and sorts them by version
+   *
+   * @param {Array<ApiDocMetadataUpdate>} updates Original updates to be merged
+   * @param {Array<ApiDocMetadataChange>} changes Changes to be merged into updates
+   * @returns {Array<ApiDocMetadataChange>} Mapped, merged and sorted changes
+   */
+  const mergeUpdatesIntoChanges = (updates, changes) => {
+    // Maps the `updates` array into the same format used by the `changes` array
+    // So that for generators such as HTML, we render all the changes + updates
+    // into one single list of changes, for example a HTML table
+    const mappedUpdatesIntoChanges = updates.map(({ version, type }) => ({
+      version,
+      'pr-url': undefined,
+      description: `${DOC_API_UPDATE_MAPPING[type]}: ${version.join(', ')}`,
+    }));
+
+    // Sorts the updates and changes by the first version on a given entry
+    return [...mappedUpdatesIntoChanges, ...changes].sort((a, b) =>
+      compare(coerceSemVer(a.version[0]), coerceSemVer(b.version[0]))
+    );
+  };
+
   /**
    * This holds a temporary buffer of raw metadata before being
    * transformed into NavigationEntries and MetadataEntries
@@ -31,8 +57,13 @@ const createMetadata = slugger => {
       name: undefined,
       depth: -1,
     },
-    properties: {},
-    stability: undefined,
+    properties: {
+      type: undefined,
+      source_link: undefined,
+      updates: [],
+      changes: [],
+    },
+    stability: createTree('root', []),
   };
 
   return {
@@ -47,10 +78,10 @@ const createMetadata = slugger => {
     /**
      * Set the Stability Index of a given Metadata
      *
-     * @param {ApiDocMetadataEntry['stability']} stability The new stability metadata
+     * @param {import('unist').Parent} stability The stability index node to be added
      */
-    setStability: stability => {
-      internalMetadata.stability = stability;
+    addStability: stability => {
+      internalMetadata.stability.children.push(stability);
     },
     /**
      * Set the Metadata (from YAML if exists) properties to the current Metadata entry
@@ -61,13 +92,27 @@ const createMetadata = slugger => {
      * meaning that this method can be called multiple times to update the properties
      * and complement each set of data.
      *
+     * Note: This ensures only valid properties get defined and that we don't accidentally override
+     * values, when we just want to complement them whenever possible.
+     *
      * @param {Partial<ApiDocRawMetadataEntry>} properties Extra Metadata properties to be defined
      */
     updateProperties: properties => {
-      internalMetadata.properties = {
-        ...internalMetadata.properties,
-        ...properties,
-      };
+      if (properties.type) {
+        internalMetadata.properties.type = properties.type;
+      }
+
+      if (properties.source_link) {
+        internalMetadata.properties.source_link = properties.source_link;
+      }
+
+      if (properties.changes) {
+        internalMetadata.properties.changes.push(...properties.changes);
+      }
+
+      if (properties.updates) {
+        internalMetadata.properties.updates.push(...properties.updates);
+      }
     },
     /**
      * Generates a new Navigation entry and pushes them to the internal collection
@@ -90,7 +135,6 @@ const createMetadata = slugger => {
 
       const {
         type: yamlType,
-        name: yamlName,
         source_link: sourceLink,
         updates = [],
         changes = [],
@@ -99,10 +143,14 @@ const createMetadata = slugger => {
       // We override the type of the heading if we have a YAML type
       internalMetadata.heading.type = yamlType || internalMetadata.heading.type;
 
+      // Maps the Stability Index AST nodes into a JSON objects from their data properties
+      internalMetadata.stability.toJSON = () =>
+        internalMetadata.stability.children.map(node => node.data);
+
       // Returns the Metadata entry for the API doc
       return {
         // The API file basename (without the extension)
-        api: yamlName || apiDoc.stem,
+        api: apiDoc.stem,
         // The path/slug of the API section
         slug: `${apiDoc.stem}.html${slugHash}`,
         // The source link of said API section
@@ -110,7 +158,7 @@ const createMetadata = slugger => {
         // The latest updates to an API section
         updates,
         // The full-changeset to an API section
-        changes,
+        changes: mergeUpdatesIntoChanges(updates, changes),
         // The Heading metadata
         heading: internalMetadata.heading,
         // The Stability Index of the API section

--- a/src/releases.mjs
+++ b/src/releases.mjs
@@ -1,6 +1,7 @@
 'use strict';
 
 import { readFile } from 'node:fs/promises';
+
 import { coerce } from 'semver';
 
 // A ReGeX for retrieving Node.js version headers from the CHANGELOG.md
@@ -45,7 +46,7 @@ const createNodeReleases = changelogPath => {
    * Retrieves all Node.js major versions from the provided CHANGELOG.md file
    * and returns an array of objects containing the version and LTS status.
    *
-   * @returns {Promise<Array<import('./types.d.ts').ApiDocReleaseEntry>>}
+   * @returns {Promise<Array<ApiDocReleaseEntry>>}
    */
   const getAllMajors = async () => {
     const changelog = await changelogStrategy;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,75 +1,89 @@
 import type { SemVer } from 'semver';
-import type { Parent, Node } from 'unist';
+import type { Parent, Node, Data } from 'unist';
 
 // String serialization of the AST tree
 // @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#tojson_behavior
-export interface WithJSON<T extends Node, J extends any = any> extends T {
+interface WithJSON<T extends Node, J extends any = any> extends T {
   toJSON: () => J;
 }
 
-export interface StabilityIndexMetadataEntry {
-  index: number;
-  description: string;
+// Unist Node with typed Data, which allows better type inference
+interface NodeWithData<T extends Node, J extends Data> extends T {
+  data: J;
 }
 
-export interface HeadingMetadataEntry {
-  type:
-    | 'event'
-    | 'method'
-    | 'property'
-    | 'class'
-    | 'module'
-    | 'classMethod'
-    | 'ctor';
-  text: string;
-  name: string;
-  depth: number;
-}
+declare global {
+  export interface StabilityIndexMetadataEntry {
+    index: number;
+    description: string;
+  }
 
-export interface ApiDocMetadataChange {
-  // The Node.js version or versions where said change was introduced simultaneously
-  version: string | string[];
-  // The GitHub PR URL of said change
-  'pr-url': string;
-  // The description of said change
-  description: string;
-}
+  export interface StabilityIndexParent extends Parent {
+    children: Array<NodeWithData<Node, StabilityIndexMetadataEntry>>;
+  }
 
-export interface ApiDocMetadataUpdate {
-  // The type of the API doc Metadata update
-  type: 'added' | 'removed' | 'deprecated' | 'introduced_in' | 'napiVersion';
-  // The Node.js version or versions where said metadata stability index changed
-  version: string[];
-}
+  export interface HeadingMetadataEntry {
+    type:
+      | 'event'
+      | 'method'
+      | 'property'
+      | 'class'
+      | 'module'
+      | 'classMethod'
+      | 'ctor';
+    text: string;
+    name: string;
+    depth: number;
+  }
 
-export interface ApiDocRawMetadataEntry {
-  type?: string;
-  name?: string;
-  source_link?: string;
-  updates?: ApiDocMetadataUpdate[];
-  changes?: ApiDocMetadataChange[];
-}
+  export interface ApiDocMetadataChange {
+    // The Node.js version or versions where said change was introduced simultaneously
+    version: string[];
+    // The GitHub PR URL of said change
+    'pr-url': string | undefined;
+    // The description of said change
+    description: string;
+  }
 
-export interface ApiDocMetadataEntry {
-  // The name of the API doc file without the file extension (basename)
-  api: string;
-  // The unique slug of a Heading/Navigation entry which is linkable through an anchor
-  slug: string;
-  // The GitHub URL to the source of the API entry
-  sourceLink: string | undefined;
-  // Any updates to the API doc Metadata
-  updates: ApiDocMetadataUpdate[];
-  // Any changes to the API doc Metadata
-  changes: ApiDocMetadataChange[];
-  // The parsed Markdown content of a Navigation Entry
-  heading: HeadingMetadataEntry;
-  // The API doc metadata Entry Stability Index if exists
-  stability: WithJSON<Parent, StabilityIndexMetadataEntry> | undefined;
-  // The subtree containing all Nodes of the API doc entry
-  content: WithJSON<Parent, string>;
-}
+  export interface ApiDocMetadataUpdate {
+    // The type of the API doc Metadata update
+    type: 'added' | 'removed' | 'deprecated' | 'introduced_in' | 'napiVersion';
+    // The Node.js version or versions where said metadata stability index changed
+    version: string[];
+  }
 
-export interface ApiDocReleaseEntry {
-  version: SemVer;
-  isLts: boolean;
+  export interface ApiDocRawMetadataEntry {
+    type?: string;
+    name?: string;
+    source_link?: string;
+    updates?: ApiDocMetadataUpdate[];
+    changes?: ApiDocMetadataChange[];
+  }
+
+  export interface ApiDocMetadataEntry {
+    // The name of the API doc file without the file extension (basename)
+    api: string;
+    // The unique slug of a Heading/Navigation entry which is linkable through an anchor
+    slug: string;
+    // The GitHub URL to the source of the API entry
+    sourceLink: string | undefined;
+    // Any updates to the API doc Metadata
+    updates: ApiDocMetadataUpdate[];
+    // Any changes to the API doc Metadata
+    changes: ApiDocMetadataChange[];
+    // The parsed Markdown content of a Navigation Entry
+    heading: HeadingMetadataEntry;
+    // The API doc metadata Entry Stability Index if exists
+    stability: WithJSON<
+      StabilityIndexParent,
+      Array<StabilityIndexMetadataEntry>
+    >;
+    // The subtree containing all Nodes of the API doc entry
+    content: WithJSON<Parent, string>;
+  }
+
+  export interface ApiDocReleaseEntry {
+    version: SemVer;
+    isLts: boolean;
+  }
 }

--- a/src/utils/generators.mjs
+++ b/src/utils/generators.mjs
@@ -1,0 +1,24 @@
+'use strict';
+
+import { coerce } from 'semver';
+
+/**
+ * @TODO: This should not be necessary, and indicates errors within the API docs
+ * @TODO: Hookup into a future Validation/Linting API
+ *
+ * This is a safe fallback to ensure that we always have a SemVer compatible version
+ * even if the input is not a valid SemVer string
+ *
+ * @param {string|import('semver').SemVer} version SemVer compatible version (maybe)
+ * @returns {import('semver').SemVer} SemVer compatible version
+ */
+export const coerceSemVer = version => {
+  const coercedVersion = coerce(version);
+
+  if (coercedVersion === null) {
+    // @TODO: Linter to complain about invalid SemVer strings
+    return coerce('0.0.0-REPLACEME');
+  }
+
+  return coercedVersion;
+};

--- a/src/utils/parser.mjs
+++ b/src/utils/parser.mjs
@@ -76,7 +76,7 @@ export const transformTypeToReferenceLink = type => {
   // Note that if some failed to get replaced, only the valid ones will be returned
   // NOTE: Based on the original code, we don't seem to care when we fail specific entries to be replaced
   // although I believe this should be revisited and either show the original type content or show a warning
-  return markdownLinks || typeInput;
+  return markdownLinks || type;
 };
 
 /**

--- a/src/utils/remark.mjs
+++ b/src/utils/remark.mjs
@@ -1,0 +1,7 @@
+'use strict';
+
+import { remark } from 'remark';
+import remarkGfm from 'remark-gfm';
+
+// Retrieves an instance of Remark configured to parse GFM (GitHub Flavored Markdown)
+export const getRemark = () => remark().use(remarkGfm);


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR incorporates the code refactors and bug fixes introduced from #55 into the codebase, splitting the actual generator changes done in #55 from the plain bug fixes and code refactors.

### Refactors:

- Move remark imports and remark logic (for crating processors) to a dedicated `remark.mjs` file
- Updated ESLint config to be "namespace"
- Export the common types into a global namespace, to prevent unnecessary repeated JSdoc type imports and typedefs
- Updated some imports to by type imports whenever possible
- Reordered imports using default import sorter
- Support multiple stability index entries per section, instead of just one.
- Merge metadata `update` entries into `changes` by mapping the `update` entries into the same format used by `changes` within `metadata.mjs`
- Better types for WithJSON and for the Stability Index entries

### Bug Fixes

- Fixed parser excluding the last node when on the last section of the document
- Fixed specific metadata entries being lost since they were not being merged
- Fixed incorrect mapping of `DOC_TYPES_MAPPING_OTHER` on the `utils/parsers.mjs`
- Moved type link replacement to be done outside of the AST process.

## Validation

The `json-simple` generator should still work as expected