### PR TITLE
feat: improved parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
         "commander": "^12.1.0",
         "github-slugger": "^2.0.0",
         "glob": "^11.0.0",
-        "remark": "^15.0.1",
         "remark-gfm": "^4.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
         "semver": "^7.6.3",
+        "unified": "^11.0.5",
         "unist-builder": "^4.0.0",
         "unist-util-find-after": "^5.0.0",
         "unist-util-position": "^5.0.0",
@@ -2821,22 +2823,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/remark": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/remark/-/remark-15.0.1.tgz",
-      "integrity": "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
     },
     "node_modules/remark-gfm": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "test": "node --test",
     "test:watch": "node --test --watch",
     "test:coverage": "node --experimental-test-coverage --test",
-    "prepare": "husky"
+    "prepare": "husky",
+    "run": "node bin/cli.mjs",
+    "watch": "node --watch bin/cli.mjs"
   },
   "bin": {
     "api-docs-tooling": "./bin/cli.mjs"
@@ -27,9 +29,11 @@
     "commander": "^12.1.0",
     "github-slugger": "^2.0.0",
     "glob": "^11.0.0",
-    "remark": "^15.0.1",
     "remark-gfm": "^4.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
     "semver": "^7.6.3",
+    "unified": "^11.0.5",
     "unist-builder": "^4.0.0",
     "unist-util-find-after": "^5.0.0",
     "unist-util-position": "^5.0.0",

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -7,6 +7,10 @@ export const DOC_NODE_VERSION = process.version;
 export const DOC_NODE_CHANGELOG_URL =
   'https://raw.githubusercontent.com/nodejs/node/HEAD/CHANGELOG.md';
 
+// This is the perma-link within the API docs that reference the Stability Index
+export const DOC_API_STABILITY_SECTION_REF_URL =
+  'documentation.html#stability-index';
+
 // This is the base URL of the MDN Web documentation
 export const DOC_MDN_BASE_URL = 'https://developer.mozilla.org/en-US/docs/Web/';
 
@@ -118,192 +122,227 @@ export const DOC_TYPES_MAPPING_GLOBALS = {
 
 // This is a mapping for types within the Markdown content and their respective
 // Node.js types within the Node.js API docs (refers to a different API doc page)
-// @note These hashes are generated with the GitHub Slugger
+// Note: These hashes are generated with the GitHub Slugger
 export const DOC_TYPES_MAPPING_NODE_MODULES = {
-  AbortController: 'globals.html#abortcontroller',
-  AbortSignal: 'globals.html#abortsignal',
+  AbortController: 'globals.html#class-abortcontroller',
+  AbortSignal: 'globals.html#class-abortsignal',
 
-  Blob: 'buffer.html#blob',
-
-  BroadcastChannel: 'worker_threads.html#broadcastchannel-extends-eventtarget',
-
+  AlgorithmIdentifier: 'webcrypto.html#class-algorithmidentifier',
   AsyncHook: 'async_hooks.html#async_hookscreatehookcallbacks',
-  AsyncResource: 'async_hooks.html#asyncresource',
+  AsyncLocalStorage: 'async_context.html#class-asynclocalstorage',
+  AsyncResource: 'async_hooks.html#class-asyncresource',
 
-  'brotli options': 'zlib.html#brotlioptions',
+  AesCbcParams: 'webcrypto.html#class-aescbcparams',
+  AesCtrParams: 'webcrypto.html#class-aesctrparams',
+  AesGcmParams: 'webcrypto.html#class-aesgcmparams',
+  AesKeyGenParams: 'webcrypto.html#class-aeskeygenparams',
 
-  Buffer: 'buffer.html#buffer',
+  Blob: 'buffer.html#class-blob',
+  BroadcastChannel:
+    'worker_threads.html#class-broadcastchannel-extends-eventtarget',
+  Buffer: 'buffer.html#class-buffer',
 
-  ChildProcess: 'child_process.html#childprocess',
+  ByteLengthQueuingStrategy: 'webstreams.html#class-bytelengthqueuingstrategy',
 
-  'cluster.Worker': 'cluster.html#worker',
+  Channel: 'diagnostics_channel.html#class-channel',
+  ChildProcess: 'child_process.html#class-childprocess',
+  Cipher: 'crypto.html#class-cipher',
+  ClientHttp2Session: 'http2.html#class-clienthttp2session',
+  ClientHttp2Stream: 'http2.html#class-clienthttp2stream',
 
-  Cipher: 'crypto.html#cipher',
-  Decipher: 'crypto.html#decipher',
-  DiffieHellman: 'crypto.html#diffiehellman',
-  DiffieHellmanGroup: 'crypto.html#diffiehellmangroup',
-  ECDH: 'crypto.html#ecdh',
-  Hash: 'crypto.html#hash',
-  Hmac: 'crypto.html#hmac',
-  KeyObject: 'crypto.html#keyobject',
-  Sign: 'crypto.html#sign',
-  Verify: 'crypto.html#verify',
+  CountQueuingStrategy: 'webstreams.html#class-countqueuingstrategy',
+
+  Crypto: 'webcrypto.html#class-crypto',
+  CryptoKey: 'webcrypto.html#class-cryptokey',
+  CryptoKeyPair: 'webcrypto.html#class-cryptokeypair',
+
+  CustomEvent: 'events.html#class-customevent',
+
+  Decipher: 'crypto.html#class-decipher',
+  DiffieHellman: 'crypto.html#class-diffiehellman',
+  DiffieHellmanGroup: 'crypto.html#class-diffiehellmangroup',
+  Domain: 'domain.html#class-domain',
+
+  Duplex: 'stream.html#class-streamduplex',
+
+  ECDH: 'crypto.html#class-ecdh',
+  EcdhKeyDeriveParams: 'webcrypto.html#class-ecdhkeyderiveparams',
+  EcdsaParams: 'webcrypto.html#class-ecdsaparams',
+  EcKeyGenParams: 'webcrypto.html#class-eckeygenparams',
+  EcKeyImportParams: 'webcrypto.html#class-eckeyimportparams',
+  Ed448Params: 'webcrypto.html#class-ed448params',
+
+  Event: 'events.html#class-event',
+  EventEmitter: 'events.html#class-eventemitter',
+  EventListener: 'events.html#event-listener',
+  EventTarget: 'events.html#class-eventtarget',
+
+  File: 'buffer.html#class-file',
+  FileHandle: 'fs.html#class-filehandle',
+
+  Handle: 'net.html#serverlistenhandle-backlog-callback',
+  Hash: 'crypto.html#class-hash',
+  Histogram: 'perf_hooks.html#class-histogram',
+  HkdfParams: 'webcrypto.html#class-hkdfparams',
+  Hmac: 'crypto.html#class-hmac',
+  HmacImportParams: 'webcrypto.html#class-hmacimportparams',
+  HmacKeyGenParams: 'webcrypto.html#class-hmackeygenparams',
+
+  Http2SecureServer: 'http2.html#class-http2secureserver',
+  Http2Server: 'http2.html#class-http2server',
+  Http2Session: 'http2.html#class-http2session',
+  Http2Stream: 'http2.html#class-http2stream',
+
+  Immediate: 'timers.html#class-immediate',
+
+  IntervalHistogram:
+    'perf_hooks.html#class-intervalhistogram-extends-histogram',
+
+  KeyObject: 'crypto.html#class-keyobject',
+
+  MIMEParams: 'util.html#class-utilmimeparams',
+  MessagePort: 'worker_threads.html#class-messageport',
+
+  MockModuleContext: 'test.html#class-mockmodulecontext',
+
+  NodeEventTarget: 'events.html#class-nodeeventtarget',
+
+  Pbkdf2Params: 'webcrypto.html#class-pbkdf2params',
+  PerformanceEntry: 'perf_hooks.html#class-performanceentry',
+  PerformanceNodeTiming: 'perf_hooks.html#class-performancenodetiming',
+  PerformanceObserver: 'perf_hooks.html#class-performanceobserver',
+  PerformanceObserverEntryList:
+    'perf_hooks.html#class-performanceobserverentrylist',
+
+  Readable: 'stream.html#class-streamreadable',
+  ReadableByteStreamController:
+    'webstreams.html#class-readablebytestreamcontroller',
+  ReadableStream: 'webstreams.html#class-readablestream',
+  ReadableStreamBYOBReader: 'webstreams.html#class-readablestreambyobreader',
+  ReadableStreamBYOBRequest: 'webstreams.html#class-readablestreambyobrequest',
+  ReadableStreamDefaultController:
+    'webstreams.html#class-readablestreamdefaultcontroller',
+  ReadableStreamDefaultReader:
+    'webstreams.html#class-readablestreamdefaultreader',
+
+  RecordableHistogram:
+    'perf_hooks.html#class-recordablehistogram-extends-histogram',
+
+  RsaHashedImportParams: 'webcrypto.html#class-rsahashedimportparams',
+  RsaHashedKeyGenParams: 'webcrypto.html#class-rsahashedkeygenparams',
+  RsaOaepParams: 'webcrypto.html#class-rsaoaepparams',
+  RsaPssParams: 'webcrypto.html#class-rsapssparams',
+
+  ServerHttp2Session: 'http2.html#class-serverhttp2session',
+  ServerHttp2Stream: 'http2.html#class-serverhttp2stream',
+
+  Sign: 'crypto.html#class-sign',
+
+  StatementSync: 'sqlite.html#class-statementsync',
+
+  Stream: 'stream.html#stream',
+
+  SubtleCrypto: 'webcrypto.html#class-subtlecrypto',
+
+  TestsStream: 'test.html#class-testsstream',
+
+  TextDecoderStream: 'webstreams.html#class-textdecoderstream',
+  TextEncoderStream: 'webstreams.html#class-textencoderstream',
+
+  Timeout: 'timers.html#class-timeout',
+  Timer: 'timers.html#timers',
+
+  Tracing: 'tracing.html#tracing-object',
+  TracingChannel: 'diagnostics_channel.html#class-tracingchannel',
+
+  Transform: 'stream.html#class-streamtransform',
+  TransformStream: 'webstreams.html#class-transformstream',
+  TransformStreamDefaultController:
+    'webstreams.html#class-transformstreamdefaultcontroller',
+
+  URL: 'url.html#the-whatwg-url-api',
+  URLSearchParams: 'url.html#class-urlsearchparams',
+
+  Verify: 'crypto.html#class-verify',
+
+  Writable: 'stream.html#class-streamwritable',
+  WritableStream: 'webstreams.html#class-writablestream',
+  WritableStreamDefaultController:
+    'webstreams.html#class-writablestreamdefaultcontroller',
+  WritableStreamDefaultWriter:
+    'webstreams.html#class-writablestreamdefaultwriter',
+
+  Worker: 'worker_threads.html#class-worker',
+
+  X509Certificate: 'crypto.html#class-x509certificate',
+
+  'brotli options': 'zlib.html#class-brotlioptions',
+
+  'cluster.Worker': 'cluster.html#class-worker',
+
   'crypto.constants': 'crypto.html#cryptoconstants',
 
-  CryptoKey: 'webcrypto.html#cryptokey',
-  CryptoKeyPair: 'webcrypto.html#cryptokeypair',
-  Crypto: 'webcrypto.html#crypto',
-  SubtleCrypto: 'webcrypto.html#subtlecrypto',
-  RsaOaepParams: 'webcrypto.html#rsaoaepparams',
-  AlgorithmIdentifier: 'webcrypto.html#algorithmidentifier',
-  AesCtrParams: 'webcrypto.html#aesctrparams',
-  AesCbcParams: 'webcrypto.html#aescbcparams',
-  AesGcmParams: 'webcrypto.html#aesgcmparams',
-  EcdhKeyDeriveParams: 'webcrypto.html#ecdhkeyderiveparams',
-  HkdfParams: 'webcrypto.html#hkdfparams',
-  Pbkdf2Params: 'webcrypto.html#pbkdf2params',
-  HmacKeyGenParams: 'webcrypto.html#hmackeygenparams',
-  AesKeyGenParams: 'webcrypto.html#aeskeygenparams',
-  RsaHashedKeyGenParams: 'webcrypto.html#rsahashedkeygenparams',
-  EcKeyGenParams: 'webcrypto.html#eckeygenparams',
-  RsaHashedImportParams: 'webcrypto.html#rsahashedimportparams',
-  EcKeyImportParams: 'webcrypto.html#eckeyimportparams',
-  HmacImportParams: 'webcrypto.html#hmacimportparams',
-  EcdsaParams: 'webcrypto.html#ecdsaparams',
-  RsaPssParams: 'webcrypto.html#rsapssparams',
-  Ed448Params: 'webcrypto.html#ed448params',
+  'dgram.Socket': 'dgram.html#class-dgramsocket',
 
-  'dgram.Socket': 'dgram.html#dgramsocket',
+  'errors.Error': 'errors.html#class-error',
 
-  Channel: 'diagnostics_channel.html#channel',
+  'fs.Dir': 'fs.html#class-fsdir',
+  'fs.Dirent': 'fs.html#class-fsdirent',
+  'fs.FSWatcher': 'fs.html#class-fsfswatcher',
+  'fs.ReadStream': 'fs.html#class-fsreadstream',
+  'fs.StatFs': 'fs.html#class-fsstatfs',
+  'fs.Stats': 'fs.html#class-fsstats',
+  'fs.StatWatcher': 'fs.html#class-fsstatwatcher',
+  'fs.WriteStream': 'fs.html#class-fswritestream',
 
-  Domain: 'domain.html#domain',
+  'http.Agent': 'http.html#class-httpagent',
+  'http.ClientRequest': 'http.html#class-httpclientrequest',
+  'http.IncomingMessage': 'http.html#class-httpincomingmessage',
+  'http.OutgoingMessage': 'http.html#class-httpoutgoingmessage',
+  'http.Server': 'http.html#class-httpserver',
+  'http.ServerResponse': 'http.html#class-httpserverresponse',
 
-  'errors.Error': 'errors.html#error',
+  'http2.Http2ServerRequest': 'http2.html#class-http2http2serverrequest',
+  'http2.Http2ServerResponse': 'http2.html#class-http2http2serverresponse',
 
   'import.meta': 'esm.html#importmeta',
 
-  EventEmitter: 'events.html#eventemitter',
-  EventTarget: 'events.html#eventtarget',
-  Event: 'events.html#event',
-  CustomEvent: 'events.html#customevent',
-  EventListener: 'events.html#listener',
+  'module.SourceMap': 'module.html#class-modulesourcemap',
 
-  FileHandle: 'fs.html#filehandle',
-  'fs.Dir': 'fs.html#fsdir',
-  'fs.Dirent': 'fs.html#fsdirent',
-  'fs.FSWatcher': 'fs.html#fsfswatcher',
-  'fs.ReadStream': 'fs.html#fsreadstream',
-  'fs.Stats': 'fs.html#fsstats',
-  'fs.StatWatcher': 'fs.html#fsstatwatcher',
-  'fs.WriteStream': 'fs.html#fswritestream',
-
-  'http.Agent': 'http.html#httpagent',
-  'http.ClientRequest': 'http.html#httpclientrequest',
-  'http.IncomingMessage': 'http.html#httpincomingmessage',
-  'http.OutgoingMessage': 'http.html#httpoutgoingmessage',
-  'http.Server': 'http.html#httpserver',
-  'http.ServerResponse': 'http.html#httpserverresponse',
-
-  ClientHttp2Session: 'http2.html#clienthttp2session',
-  ClientHttp2Stream: 'http2.html#clienthttp2stream',
-  'HTTP/2 Headers Object': 'http2.html#headers-object',
-  'HTTP/2 Settings Object': 'http2.html#settings-object',
-  'http2.Http2ServerRequest': 'http2.html#http2http2serverrequest',
-  'http2.Http2ServerResponse': 'http2.html#http2http2serverresponse',
-  Http2SecureServer: 'http2.html#http2secureserver',
-  Http2Server: 'http2.html#http2server',
-  Http2Session: 'http2.html#http2session',
-  Http2Stream: 'http2.html#http2stream',
-  ServerHttp2Stream: 'http2.html#serverhttp2stream',
-  ServerHttp2Session: 'http2.html#serverhttp2session',
-
-  'https.Server': 'https.html#httpsserver',
-
-  module: 'modules.html#the-module-object',
-
-  'module.SourceMap': 'module.html#modulesourcemap',
-
-  require: 'modules.html#requireid',
-
-  Handle: 'net.html#serverlistenhandle-backlog-callback',
-  'net.BlockList': 'net.html#netblocklist',
-  'net.Server': 'net.html#netserver',
-  'net.Socket': 'net.html#netsocket',
-  'net.SocketAddress': 'net.html#netsocketaddress',
-
-  NodeEventTarget: 'events.html#nodeeventtarget',
+  'net.BlockList': 'net.html#class-netblocklist',
+  'net.Server': 'net.html#class-netserver',
+  'net.Socket': 'net.html#class-netsocket',
+  'net.SocketAddress': 'net.html#class-netsocketaddress',
 
   'os.constants.dlopen': 'os.html#dlopen-constants',
 
-  Histogram: 'perf_hooks.html#histogram',
-  IntervalHistogram: 'perf_hooks.html#intervalhistogram-extends-histogram',
-  RecordableHistogram: 'perf_hooks.html#recordablehistogram-extends-histogram',
-  PerformanceEntry: 'perf_hooks.html#performanceentry',
-  PerformanceNodeTiming: 'perf_hooks.html#performancenodetiming',
-  PerformanceObserver: 'perf_hooks.html#perf_hooksperformanceobserver',
-  PerformanceObserverEntryList: 'perf_hooks.html#performanceobserverentrylist',
+  'readline.Interface': 'readline.html#class-readlineinterface',
+  'readline.InterfaceConstructor': 'readline.html#class-interfaceconstructor',
+  'readlinePromises.Interface': 'readline.html#class-readlinepromisesinterface',
 
-  'readline.Interface': 'readline.html#readlineinterface',
-  'readline.InterfaceConstructor': 'readline.html#interfaceconstructor',
-  'readlinePromises.Interface': 'readline.html#readlinepromisesinterface',
+  'repl.REPLServer': 'repl.html#class-replserver',
 
-  'repl.REPLServer': 'repl.html#replserver',
+  require: 'modules.html#requireid',
 
-  Stream: 'stream.html#stream',
-  'stream.Duplex': 'stream.html#streamduplex',
-  Duplex: 'stream.html#streamduplex',
-  'stream.Readable': 'stream.html#streamreadable',
-  Readable: 'stream.html#streamreadable',
-  'stream.Transform': 'stream.html#streamtransform',
-  Transform: 'stream.html#streamtransform',
-  'stream.Writable': 'stream.html#streamwritable',
-  Writable: 'stream.html#streamwritable',
-
-  Immediate: 'timers.html#immediate',
-  Timeout: 'timers.html#timeout',
-  Timer: 'timers.html#timers',
-
-  TapStream: 'test.html#tapstream',
+  'stream.Duplex': 'stream.html#class-streamduplex',
+  'stream.Readable': 'stream.html#class-streamreadable',
+  'stream.Transform': 'stream.html#class-streamtransform',
+  'stream.Writable': 'stream.html#class-streamwritable',
 
   'tls.SecureContext': 'tls.html#tlscreatesecurecontextoptions',
-  'tls.Server': 'tls.html#tlsserver',
-  'tls.TLSSocket': 'tls.html#tlstlssocket',
+  'tls.Server': 'tls.html#class-tlsserver',
+  'tls.TLSSocket': 'tls.html#class-tlstlssocket',
 
-  Tracing: 'tracing.html#tracing-object',
+  'tty.ReadStream': 'tty.html#class-ttyreadstream',
+  'tty.WriteStream': 'tty.html#class-ttywritestream',
 
-  URL: 'url.html#the-whatwg-url-api',
-  URLSearchParams: 'url.html#urlsearchparams',
+  'vm.Module': 'vm.html#class-vmmodule',
+  'vm.Script': 'vm.html#class-vmscript',
+  'vm.SourceTextModule': 'vm.html#class-vmsourcetextmodule',
+  'vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER':
+    'vm.html#vmconstantsuse_main_context_default_loader',
 
-  'vm.Module': 'vm.html#vmmodule',
-  'vm.Script': 'vm.html#vmscript',
-  'vm.SourceTextModule': 'vm.html#vmsourcetextmodule',
-
-  MessagePort: 'worker_threads.html#messageport',
-  Worker: 'worker_threads.html#worker',
-
-  X509Certificate: 'crypto.html#x509certificate',
-
-  'zlib options': 'zlib.html#options',
-
-  ReadableStream: 'webstreams.html#readablestream',
-  ReadableStreamDefaultReader: 'webstreams.html#readablestreamdefaultreader',
-  ReadableStreamBYOBReader: 'webstreams.html#readablestreambyobreader',
-  ReadableStreamDefaultController:
-    'webstreams.html#readablestreamdefaultcontroller',
-  ReadableByteStreamController: 'webstreams.html#readablebytestreamcontroller',
-  ReadableStreamBYOBRequest: 'webstreams.html#readablestreambyobrequest',
-  WritableStream: 'webstreams.html#writablestream',
-  WritableStreamDefaultWriter: 'webstreams.html#writablestreamdefaultwriter',
-  WritableStreamDefaultController:
-    'webstreams.html#writablestreamdefaultcontroller',
-  TransformStream: 'webstreams.html#transformstream',
-  TransformStreamDefaultController:
-    'webstreams.html#transformstreamdefaultcontroller',
-  ByteLengthQueuingStrategy: 'webstreams.html#bytelengthqueuingstrategy',
-  CountQueuingStrategy: 'webstreams.html#countqueuingstrategy',
-  TextEncoderStream: 'webstreams.html#textencoderstream',
-  TextDecoderStream: 'webstreams.html#textdecoderstream',
+  'zlib options': 'zlib.html#class-options',
 };
 
 // This is a mapping for miscellaneous types within the Markdown content and their respective

--- a/src/loader.mjs
+++ b/src/loader.mjs
@@ -27,9 +27,9 @@ const createLoader = () => {
     );
 
     return resolvedFiles.map(async filePath => {
-      const fileBuffer = await readFile(filePath);
+      const fileContents = await readFile(filePath, 'utf-8');
 
-      return new VFile({ path: filePath, value: fileBuffer });
+      return new VFile({ path: filePath, value: fileContents });
     });
   };
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -36,9 +36,12 @@ declare global {
     depth: number;
   }
 
+  export interface HeadingMetadataParent
+    extends NodeWithData<Parent, HeadingMetadataEntry> {}
+
   export interface ApiDocMetadataChange {
     // The Node.js version or versions where said change was introduced simultaneously
-    version: string[];
+    version: Array<string>;
     // The GitHub PR URL of said change
     'pr-url': string | undefined;
     // The description of said change
@@ -49,15 +52,16 @@ declare global {
     // The type of the API doc Metadata update
     type: 'added' | 'removed' | 'deprecated' | 'introduced_in' | 'napiVersion';
     // The Node.js version or versions where said metadata stability index changed
-    version: string[];
+    version: Array<string>;
   }
 
   export interface ApiDocRawMetadataEntry {
     type?: string;
     name?: string;
     source_link?: string;
-    updates?: ApiDocMetadataUpdate[];
-    changes?: ApiDocMetadataChange[];
+    updates?: Array<ApiDocMetadataUpdate>;
+    changes?: Array<ApiDocMetadataChange>;
+    tags?: Array<string>;
   }
 
   export interface ApiDocMetadataEntry {
@@ -68,11 +72,11 @@ declare global {
     // The GitHub URL to the source of the API entry
     sourceLink: string | undefined;
     // Any updates to the API doc Metadata
-    updates: ApiDocMetadataUpdate[];
+    updates: Array<ApiDocMetadataUpdate>;
     // Any changes to the API doc Metadata
-    changes: ApiDocMetadataChange[];
+    changes: Array<ApiDocMetadataChange>;
     // The parsed Markdown content of a Navigation Entry
-    heading: HeadingMetadataEntry;
+    heading: WithJSON<HeadingMetadataParent, HeadingMetadataEntry>;
     // The API doc metadata Entry Stability Index if exists
     stability: WithJSON<
       StabilityIndexParent,
@@ -80,6 +84,9 @@ declare global {
     >;
     // The subtree containing all Nodes of the API doc entry
     content: WithJSON<Parent, string>;
+    // Extra YAML section entries that are stringd and serve
+    // to provide additional metadata about the API doc entry
+    tags: Array<string>;
   }
 
   export interface ApiDocReleaseEntry {

--- a/src/utils/parser.mjs
+++ b/src/utils/parser.mjs
@@ -21,14 +21,14 @@ import {
  * @returns {string} The Markdown link as a string (formatted in Markdown)
  */
 export const transformTypeToReferenceLink = type => {
-  const typeInput = type.replace('{', '').replace('}', '');
+  const typeInput = type.replace(/[{}<>]/g, '');
 
   /**
    * Handles the mapping (if there's a match) of the input text
    * into the reference type from the API docs
    *
    * @param {string} lookupPiece
-   * @returns {string | undefined} The reference URL or undefined if no match was found
+   * @returns {string} The reference URL or empty string if no match
    */
   const transformType = lookupPiece => {
     // Transform JS primitive type references into Markdown links (MDN)

--- a/src/utils/parser.mjs
+++ b/src/utils/parser.mjs
@@ -63,9 +63,8 @@ export const transformTypeToReferenceLink = type => {
     const trimmedPiece = piece.trim();
 
     // This is what we will compare against the API types mappings
-    // Thie regex below is used to remove `\[]` from the end of the type
-    // in case it is an array of a type
-    const result = transformType(trimmedPiece.replace('\\[]', ''));
+    // The ReGeX below is used to remove `[]` from the end of the type
+    const result = transformType(trimmedPiece.replace('[]', ''));
 
     // If we have a valid result and the piece is not empty, we return the Markdown link
     if (trimmedPiece.length && result.length) {

--- a/src/utils/parser.mjs
+++ b/src/utils/parser.mjs
@@ -55,7 +55,7 @@ export const transformTypeToReferenceLink = type => {
       return DOC_TYPES_MAPPING_NODE_MODULES[lookupPiece];
     }
 
-    return undefined;
+    return '';
   };
 
   const typePieces = typeInput.split('|').map(piece => {
@@ -63,19 +63,23 @@ export const transformTypeToReferenceLink = type => {
     const trimmedPiece = piece.trim();
 
     // This is what we will compare against the API types mappings
-    const result = transformType(trimmedPiece.replace(/(?:\[])+$/, ''));
+    // Thie regex below is used to remove `\[]` from the end of the type
+    // in case it is an array of a type
+    const result = transformType(trimmedPiece.replace('\\[]', ''));
 
-    return result && `[\`<${trimmedPiece}>\`](${result})`;
+    // If we have a valid result and the piece is not empty, we return the Markdown link
+    if (trimmedPiece.length && result.length) {
+      return `[\`<${trimmedPiece}>\`](${result})`;
+    }
   });
 
   // Filter out pieces that we failed to map and then join the valid ones
-  // into different links separated by a `|`
+  // into different links separated by a ` | `
   const markdownLinks = typePieces.filter(Boolean).join(' | ');
 
   // Return the replaced links or the original content if they all failed to be replaced
   // Note that if some failed to get replaced, only the valid ones will be returned
-  // NOTE: Based on the original code, we don't seem to care when we fail specific entries to be replaced
-  // although I believe this should be revisited and either show the original type content or show a warning
+  // If no valid entry exists, we return the original string/type
   return markdownLinks || type;
 };
 
@@ -96,13 +100,13 @@ export const parseYAMLIntoMetadata = yamlString => {
 
   // Ensures that the parsed YAML is an object, because even if it is not
   // i.e. a plain string or an array, it will simply not result into anything
-  /** @type {ApiDocRawMetadataEntry} */
-  const parsedYaml = yaml.parse(replacedContent);
+  /** @type {ApiDocRawMetadataEntry | string} */
+  let parsedYaml = yaml.parse(replacedContent);
 
   // Ensure that only Objects get parsed on Object.keys(), since some `<!--`
   // comments, might be just plain strings and not even a valid YAML metadata
-  if (typeof parsedYaml !== 'object') {
-    return {};
+  if (typeof parsedYaml === 'string') {
+    parsedYaml = { tags: [parsedYaml] };
   }
 
   // This cleans up the YAML metadata into something more standardized and that

--- a/src/utils/remark.mjs
+++ b/src/utils/remark.mjs
@@ -1,7 +1,11 @@
 'use strict';
 
-import { remark } from 'remark';
+import { unified } from 'unified';
+
 import remarkGfm from 'remark-gfm';
+import remarkParse from 'remark-parse';
+import remarkStringify from 'remark-stringify';
 
 // Retrieves an instance of Remark configured to parse GFM (GitHub Flavored Markdown)
-export const getRemark = () => remark().use(remarkGfm);
+export const getRemark = () =>
+  unified().use(remarkParse).use(remarkGfm).use(remarkStringify);


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR improves the parsing within the `api-docs-tooling` and does the following updates:

- Parses the Heading similar to the Stability Index, storing the original AST tree that can be reused in the future
- Updates the parsing of Markdown type references, improving its speed, reorganizing and updating the slugged classes on constants.mjs and adding missing ones from recent updates
- Fixed \[] removal from types within Markdown during the type parsing
- Explicitly use remark-parse and remark-stringify, instead of the whole remark() process
- Fixup certain types within the codebase
- VFile to permanently store the UTF-8 parsed string instead of a Buffer, as we need to look into the string value anyways
- Updated type reference regex to possibly skip unwanted matches

## Validation

JSON generation should be correct and with all types correctly parsed