### PR TITLE
fix: cli multiple input

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -22,7 +22,7 @@ program
   .description('CLI tool to generate API documentation of a Node.js project.')
   .addOption(
     new Option(
-      '-i, --input <patterns>',
+      '-i, --input [patterns...]',
       'Specify input file patterns using glob syntax'
     ).makeOptionMandatory()
   )


### PR DESCRIPTION
## Description

With this PR, if the input pattern points to more than one file, we expect it to work for all of them. In the current version, it only produces output for the first file.

## Validation

For example, expect the command below to produce output for all markdown files in the `api` directory;
```sh
npx api-docs-tooling -i PATH_TO_NODE/doc/api/*.md -t json-simple -o .
```