### PR TITLE
docs: add README help/usage output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,27 @@
     <img src="https://api.securityscorecards.dev/projects/github.com/nodejs/api-docs-tooling/badge" alt="api-docs-tooling scorecard badge" />
   </a>
 </p>
+
+## Usage
+
+Local invocation:
+
+```sh
+$ npx api-docs-tooling --help
+```
+
+```sh
+Usage: api-docs-tooling [options]
+
+CLI tool to generate API documentation of a Node.js project.
+
+Options:
+  -i, --input [patterns...]  Specify input file patterns using glob syntax
+  -o, --output <path>        Specify the relative or absolute output directory
+  -v, --version <semver>     Specify the target version of Node.js, semver compliant (default: "v22.6.0")
+  -c, --changelog <url>      Specify the path (file: or https://) to the CHANGELOG.md file (default:
+                             "https://raw.githubusercontent.com/nodejs/node/HEAD/CHANGELOG.md")
+  -t, --target [mode...]     Set the processing target modes (choices: "json-simple", "legacy-html",
+                             "legacy-html-all")
+  -h, --help                 display help for command
+```


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

While starting work on a different aspect of this codebase, I sorta forgot how to use it :smile: This PR adds a very simple usage section to the README that is a moment in time snapshot of the help output.

Will this output drift over time? It could. My team maintains [markdown-inject](https://www.npmjs.com/package/markdown-inject) for use cases like this, but it doesn't need to be introduced. 

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I've covered new added functionality with unit tests if necessary.
