### PR TITLE
feat: allow non-cli execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "run": "node bin/cli.mjs",
     "watch": "node --watch bin/cli.mjs"
   },
+  "main": "./src/index.mjs",
   "bin": {
     "api-docs-tooling": "./bin/cli.mjs"
   },

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,0 +1,8 @@
+export * as constants from './constants.mjs';
+export { default as generators } from './generators/index.mjs';
+export { default as createGenerator } from './generators.mjs';
+export { default as createLoader } from './loader.mjs';
+export { default as createMetadata } from './metadata.mjs';
+export { default as createParser } from './parser.mjs';
+export { default as createQueries } from './queries.mjs';
+export { default as createNodeReleases } from './releases.mjs';


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR adds the ability to execute this from another JS file, without the use of the CLI. That way, `man-page`, and any future generators wouldn't be limited to the CLI for execution

## Validation

Verify that all execution is working as planned.

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [-] I've covered new added functionality with unit tests if necessary.
