### PR TITLE
fix(man-page): account for optional flag arguments

### DIFF
--- a/src/generators/man-page/utils/converter.mjs
+++ b/src/generators/man-page/utils/converter.mjs
@@ -78,7 +78,12 @@ export function flagValueToMandoc(flag) {
   }
 
   // Split the flag into the name and value based on the separator ('=' or space).
-  const value = flag.split(sep)[1];
+  let value = flag.split(sep)[1];
+
+  // If the value ends with ']', the flag's argument is optional.
+  if (value.endsWith(']')) {
+    value = '[' + value;
+  }
 
   // If there is no value, return an empty string.
   if (!value) {
@@ -89,12 +94,12 @@ export function flagValueToMandoc(flag) {
   const prefix = sep === ' ' ? '' : ' Ns = Ns';
 
   // Combine prefix and formatted value.
-  return `${prefix} Ar ${value.replace(/\]$/, '')}`;
+  return `${prefix} Ar ${value}`;
 }
 
 const formatFlag = flag =>
   // 'Fl' denotes a flag, followed by an optional 'Ar' (argument).
-  `Fl ${flag.split(/[= ]/)[0].slice(1)}${flagValueToMandoc(flag)}`;
+  `Fl ${flag.split(/\[?[= ]/)[0].slice(1)}${flagValueToMandoc(flag)}`;
 
 /**
  * Converts an API option metadata entry into the Mandoc format.

--- a/src/test/man-page.test.mjs
+++ b/src/test/man-page.test.mjs
@@ -94,6 +94,10 @@ describe('Mandoc Conversion', () => {
           expected: ' Ns = Ns Ar value1,value2,value3',
         },
         { input: '-x', expected: '' },
+        {
+          input: '--flag[=optional value]',
+          expected: ' Ns = Ns Ar [optional value]',
+        },
       ];
       runTests(cases, flagValueToMandoc);
     });


### PR DESCRIPTION
## Description

Some flags (rarely, but still) have optional parameters, which was not reflected in the generated man-page.

## Validation

See the tests to ensure validation.

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I've covered new added functionality with unit tests if necessary.
