### PR TITLE
fix: don't assume heading type is `module`

### DIFF
--- a/src/test/queries.test.mjs
+++ b/src/test/queries.test.mjs
@@ -53,7 +53,6 @@ describe('createQueries', () => {
             depth: 2,
             name: 'Test Heading',
             text: 'Test Heading',
-            type: 'module',
           },
           depth: 2,
         });

--- a/src/utils/parser.mjs
+++ b/src/utils/parser.mjs
@@ -130,5 +130,5 @@ export const parseHeadingIntoMetadata = (heading, depth) => {
     }
   }
 
-  return { text: heading, type: 'module', name: heading, depth };
+  return { text: heading, name: heading, depth };
 };

--- a/src/utils/tests/parser.test.mjs
+++ b/src/utils/tests/parser.test.mjs
@@ -60,7 +60,6 @@ describe('parseYAMLIntoMetadata', () => {
     const input = '## test';
     const expectedOutput = {
       text: '## test',
-      type: 'module',
       name: '## test',
       depth: 2,
     };


### PR DESCRIPTION
## Description

According to the legacy parser:
<https://github.com/nodejs/node/blob/0a00217a5f67ef4a22384cfc80eb6dd9a917fdc1/tools/doc/json.mjs#L478-L489>

As shown above, the heading should *not* have a default value. The generators should decide whether a `misc` or `module` heading is appropiate based on the heading of the parent.

## Validation

See updated tests

## Related Issues

#139

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I've covered new added functionality with unit tests if necessary.
