### PR TITLE
feat: legacy json generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ Options:
   -o, --output <path>        Specify the relative or absolute output directory
   -v, --version <semver>     Specify the target version of Node.js, semver compliant (default: "v22.6.0")
   -c, --changelog <url>      Specify the path (file: or https://) to the CHANGELOG.md file (default: "https://raw.githubusercontent.com/nodejs/node/HEAD/CHANGELOG.md")
-  -t, --target [mode...]     Set the processing target modes (choices: "json-simple", "legacy-html", "legacy-html-all", "man-page")
+  -t, --target [mode...]     Set the processing target modes (choices: "json-simple", "legacy-html", "legacy-html-all", "man-page", "legacy-json", "legacy-json-all")
   -h, --help                 display help for command
 ```

--- a/shiki.config.mjs
+++ b/shiki.config.mjs
@@ -30,7 +30,7 @@ export default {
   // Only register the languages that the API docs use
   // and override the JavaScript language with the aliases
   langs: [
-    { ...javaScriptLanguage[0], aliases: ['mjs', 'cjs', 'js'] },
+    ...httpLanguage,
     ...jsonLanguage,
     ...typeScriptLanguage,
     ...shellScriptLanguage,
@@ -40,7 +40,7 @@ export default {
     ...diffLanguage,
     ...cLanguage,
     ...cPlusPlusLanguage,
-    ...httpLanguage,
     ...coffeeScriptLanguage,
+    { ...javaScriptLanguage[0], aliases: ['mjs', 'cjs', 'js'] },
   ],
 };

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -58,7 +58,14 @@ export const DOC_API_SLUGS_REPLACEMENTS = [
 // is a specific type of API Doc entry (e.g., Event, Class, Method, etc)
 // and to extract the inner content of said Heading to be used as the API doc entry name
 export const DOC_API_HEADING_TYPES = [
-  { type: 'method', regex: /^`?([A-Z]\w+(?:\.[A-Z]\w+)*\.\w+)\([^)]*\)`?$/i },
+  {
+    type: 'method',
+    regex:
+      // Group 1: foo[bar]()
+      // Group 2: foo.bar()
+      // Group 3: foobar()
+      /^`?(?:\w*(?:(\[[^\]]+\])|(?:\.(\w+)))|(\w+))\([^)]*\)`?$/i,
+  },
   { type: 'event', regex: /^Event: +`?['"]?([^'"]+)['"]?`?$/i },
   {
     type: 'class',
@@ -71,11 +78,13 @@ export const DOC_API_HEADING_TYPES = [
   },
   {
     type: 'classMethod',
-    regex: /^Static method: +`?([A-Z]\w+(?:\.[A-Z]\w+)*\.\w+)\([^)]*\)`?$/i,
+    regex:
+      /^Static method: +`?[A-Z]\w+(?:\.[A-Z]\w+)*(?:(\[\w+\.\w+\])|\.(\w+))\([^)]*\)`?$/i,
   },
   {
     type: 'property',
-    regex: /^(?:Class property: +)?`?([A-Z]\w+(?:\.[A-Z]\w+)*\.\w+)`?$/i,
+    regex:
+      /^(?:Class property: +)?`?[A-Z]\w+(?:\.[A-Z]\w+)*(?:(\[\w+\.\w+\])|\.(\w+))`?$/i,
   },
 ];
 

--- a/src/generators/index.mjs
+++ b/src/generators/index.mjs
@@ -4,10 +4,14 @@ import jsonSimple from './json-simple/index.mjs';
 import legacyHtml from './legacy-html/index.mjs';
 import legacyHtmlAll from './legacy-html-all/index.mjs';
 import manPage from './man-page/index.mjs';
+import legacyJson from './legacy-json/index.mjs';
+import legacyJsonAll from './legacy-json-all/index.mjs';
 
 export default {
   'json-simple': jsonSimple,
   'legacy-html': legacyHtml,
   'legacy-html-all': legacyHtmlAll,
   'man-page': manPage,
+  'legacy-json': legacyJson,
+  'legacy-json-all': legacyJsonAll,
 };

--- a/src/generators/legacy-html/assets/api.js
+++ b/src/generators/legacy-html/assets/api.js
@@ -165,8 +165,6 @@
 
         let code = '';
 
-        console.log(parentNode);
-
         if (flavorToggle) {
           if (flavorToggle.checked) {
             code = parentNode.querySelector('.mjs').textContent;

--- a/src/generators/legacy-json-all/index.mjs
+++ b/src/generators/legacy-json-all/index.mjs
@@ -21,6 +21,12 @@ export default {
 
   dependsOn: 'legacy-json',
 
+  /**
+   *
+   * @param input
+   * @param root0
+   * @param root0.output
+   */
   async generate(input, { output }) {
     /**
      * The consolidated output object that will contain

--- a/src/generators/legacy-json-all/index.mjs
+++ b/src/generators/legacy-json-all/index.mjs
@@ -4,6 +4,9 @@ import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 /**
+ * This generator consolidates data from the `legacy-json` generator into a single
+ * JSON file (`all.json`).
+ *
  * @typedef {Array<import('../legacy-json/types.d.ts').Section>} Input
  *
  * @type {import('../types.d.ts').GeneratorMetadata<Input, import('./types.d.ts').Output>}
@@ -20,6 +23,9 @@ export default {
 
   async generate(input, { output }) {
     /**
+     * The consolidated output object that will contain
+     * combined data from all sections in the input.
+     *
      * @type {import('./types.d.ts').Output}
      */
     const generatedValue = {

--- a/src/generators/legacy-json-all/index.mjs
+++ b/src/generators/legacy-json-all/index.mjs
@@ -22,10 +22,10 @@ export default {
   dependsOn: 'legacy-json',
 
   /**
+   * Generates the legacy JSON `all.json` file.
    *
-   * @param input
-   * @param root0
-   * @param root0.output
+   * @param {Input} input
+   * @param {Partial<GeneratorOptions>} options
    */
   async generate(input, { output }) {
     /**

--- a/src/generators/legacy-json-all/index.mjs
+++ b/src/generators/legacy-json-all/index.mjs
@@ -1,0 +1,54 @@
+'use strict';
+
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+/**
+ * @typedef {Array<import('../legacy-json/types.d.ts').Section>} Input
+ *
+ * @type {import('../types.d.ts').GeneratorMetadata<Input, import('./types.d.ts').Output>}
+ */
+export default {
+  name: 'legacy-json-all',
+
+  version: '1.0.0',
+
+  description:
+    'Generates the `all.json` file from the `legacy-json` generator, which includes all the modules in one single file.',
+
+  dependsOn: 'legacy-json',
+
+  async generate(input, { output }) {
+    /**
+     * @type {import('./types.d.ts').Output}
+     */
+    const generatedValue = {
+      miscs: [],
+      modules: [],
+      classes: [],
+      globals: [],
+      methods: [],
+    };
+
+    const propertiesToCopy = [
+      'miscs',
+      'modules',
+      'classes',
+      'globals',
+      'methods',
+    ];
+
+    input.forEach(section => {
+      // Copy the relevant properties from each section into our output
+      propertiesToCopy.forEach(property => {
+        if (section[property]) {
+          generatedValue[property].push(...section[property]);
+        }
+      });
+    });
+
+    await writeFile(join(output, 'all.json'), JSON.stringify(generatedValue));
+
+    return generatedValue;
+  },
+};

--- a/src/generators/legacy-json-all/index.mjs
+++ b/src/generators/legacy-json-all/index.mjs
@@ -53,7 +53,9 @@ export default {
       });
     });
 
-    await writeFile(join(output, 'all.json'), JSON.stringify(generatedValue));
+    if (output) {
+      await writeFile(join(output, 'all.json'), JSON.stringify(generatedValue));
+    }
 
     return generatedValue;
   },

--- a/src/generators/legacy-json-all/types.d.ts
+++ b/src/generators/legacy-json-all/types.d.ts
@@ -1,0 +1,14 @@
+import {
+  MiscSection,
+  Section,
+  SignatureSection,
+  ModuleSection,
+} from '../legacy-json/types';
+
+export interface Output {
+  miscs: Array<MiscSection>;
+  modules: Array<Section>;
+  classes: Array<SignatureSection>;
+  globals: Array<ModuleSection | { type: 'global' }>;
+  methods: Array<SignatureSection>;
+}

--- a/src/generators/legacy-json/constants.mjs
+++ b/src/generators/legacy-json/constants.mjs
@@ -1,0 +1,18 @@
+// Grabs a method's return value
+export const RETURN_EXPRESSION = /^returns?\s*:?\s*/i;
+
+// Grabs a method's name
+export const NAME_EXPRESSION = /^['`"]?([^'`": {]+)['`"]?\s*:?\s*/;
+
+// Denotes a method's type
+export const TYPE_EXPRESSION = /^\{([^}]+)\}\s*/;
+
+// Checks if there's a leading hyphen
+export const LEADING_HYPHEN = /^-\s*/;
+
+// Grabs the default value if present
+export const DEFAULT_EXPRESSION = /\s*\*\*Default:\*\*\s*([^]+)$/i;
+
+// Grabs the parameters from a method's signature
+//  ex/ 'new buffer.Blob([sources[, options]])'.match(PARAM_EXPRESSION) === ['([sources[, options]])', '[sources[, options]]']
+export const PARAM_EXPRESSION = /\((.+)\);?$/;

--- a/src/generators/legacy-json/constants.mjs
+++ b/src/generators/legacy-json/constants.mjs
@@ -16,3 +16,21 @@ export const DEFAULT_EXPRESSION = /\s*\*\*Default:\*\*\s*([^]+)$/i;
 // Grabs the parameters from a method's signature
 //  ex/ 'new buffer.Blob([sources[, options]])'.match(PARAM_EXPRESSION) === ['([sources[, options]])', '[sources[, options]]']
 export const PARAM_EXPRESSION = /\((.+)\);?$/;
+
+// The plurals associated with each section type.
+export const SECTION_TYPE_PLURALS = {
+  module: 'modules',
+  misc: 'miscs',
+  class: 'classes',
+  method: 'methods',
+  property: 'properties',
+  global: 'globals',
+  example: 'examples',
+  ctor: 'signatures',
+  classMethod: 'classMethods',
+  event: 'events',
+  var: 'vars',
+};
+
+// The keys to not promote when promoting children.
+export const UNPROMOTED_KEYS = ['textRaw', 'name', 'type', 'desc', 'miscs'];

--- a/src/generators/legacy-json/index.mjs
+++ b/src/generators/legacy-json/index.mjs
@@ -28,10 +28,10 @@ export default {
   dependsOn: 'ast',
 
   /**
+   * Generates a legacy JSON file.
    *
-   * @param input
-   * @param root0
-   * @param root0.output
+   * @param {Input} input
+   * @param {Partial<GeneratorOptions>} options
    */
   async generate(input, { output }) {
     const buildSection = createSectionBuilder();

--- a/src/generators/legacy-json/index.mjs
+++ b/src/generators/legacy-json/index.mjs
@@ -7,12 +7,12 @@ import { createSectionBuilder } from './utils/buildSection.mjs';
 
 /**
  * This generator is responsible for generating the legacy JSON files for the
- *  legacy API docs for retro-compatibility. It is to be replaced while we work
- *  on the new schema for this file.
+ * legacy API docs for retro-compatibility. It is to be replaced while we work
+ * on the new schema for this file.
  *
  * This is a top-level generator, intaking the raw AST tree of the api docs.
  * It generates JSON files to the specified output directory given by the
- *  config.
+ * config.
  *
  * @typedef {Array<ApiDocMetadataEntry>} Input
  *
@@ -27,6 +27,12 @@ export default {
 
   dependsOn: 'ast',
 
+  /**
+   *
+   * @param input
+   * @param root0
+   * @param root0.output
+   */
   async generate(input, { output }) {
     const buildSection = createSectionBuilder();
 

--- a/src/generators/legacy-json/index.mjs
+++ b/src/generators/legacy-json/index.mjs
@@ -55,10 +55,12 @@ export default {
         const section = processModuleNodes(node);
 
         // Write it to the output file
-        await writeFile(
-          join(output, `${node.api}.json`),
-          JSON.stringify(section)
-        );
+        if (output) {
+          await writeFile(
+            join(output, `${node.api}.json`),
+            JSON.stringify(section)
+          );
+        }
       })
     );
 

--- a/src/generators/legacy-json/index.mjs
+++ b/src/generators/legacy-json/index.mjs
@@ -1,0 +1,67 @@
+'use strict';
+
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { groupNodesByModule } from '../../utils/generators.mjs';
+import buildSection from './utils/buildSection.mjs';
+
+/**
+ * This generator is responsible for generating the legacy JSON files for the
+ *  legacy API docs for retro-compatibility. It is to be replaced while we work
+ *  on the new schema for this file.
+ *
+ * This is a top-level generator, intaking the raw AST tree of the api docs.
+ * It generates JSON files to the specified output directory given by the
+ *  config.
+ *
+ * @typedef {Array<ApiDocMetadataEntry>} Input
+ *
+ * @type {import('../types.d.ts').GeneratorMetadata<Input, import('./types.d.ts').Section[]>}
+ */
+export default {
+  name: 'legacy-json',
+
+  version: '1.0.0',
+
+  description: 'Generates the legacy version of the JSON API docs.',
+
+  dependsOn: 'ast',
+
+  async generate(input, { output }) {
+    // This array holds all the generated values for each module
+    const generatedValues = [];
+
+    const groupedModules = groupNodesByModule(input);
+
+    // Gets the first nodes of each module, which is considered the "head"
+    const headNodes = input.filter(node => node.heading.depth === 1);
+
+    /**
+     * @param {ApiDocMetadataEntry} head
+     * @returns {import('./types.d.ts').ModuleSection}
+     */
+    const processModuleNodes = head => {
+      const nodes = groupedModules.get(head.api);
+
+      const section = buildSection(head, nodes);
+      generatedValues.push(section);
+
+      return section;
+    };
+
+    await Promise.all(
+      headNodes.map(async node => {
+        // Get the json for the node's section
+        const section = processModuleNodes(node);
+
+        // Write it to the output file
+        await writeFile(
+          join(output, `${node.api}.json`),
+          JSON.stringify(section)
+        );
+      })
+    );
+
+    return generatedValues;
+  },
+};

--- a/src/generators/legacy-json/index.mjs
+++ b/src/generators/legacy-json/index.mjs
@@ -3,7 +3,7 @@
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { groupNodesByModule } from '../../utils/generators.mjs';
-import buildSection from './utils/buildSection.mjs';
+import { createSectionBuilder } from './utils/buildSection.mjs';
 
 /**
  * This generator is responsible for generating the legacy JSON files for the
@@ -28,6 +28,8 @@ export default {
   dependsOn: 'ast',
 
   async generate(input, { output }) {
+    const buildSection = createSectionBuilder();
+
     // This array holds all the generated values for each module
     const generatedValues = [];
 

--- a/src/generators/legacy-json/types.d.ts
+++ b/src/generators/legacy-json/types.d.ts
@@ -1,83 +1,275 @@
 import { ListItem } from 'mdast';
 
+/**
+ * Represents an entry in a hierarchical structure, extending from ApiDocMetadataEntry.
+ * It includes children entries organized in a hierarchy.
+ */
 export interface HierarchizedEntry extends ApiDocMetadataEntry {
-  hierarchyChildren: Array<ApiDocMetadataEntry>;
+  /**
+   * List of child entries that are part of this entry's hierarchy.
+   */
+  hierarchyChildren: ApiDocMetadataEntry[];
 }
 
+/**
+ * Contains metadata related to changes, additions, removals, and deprecated statuses of an entry.
+ */
 export interface Meta {
-  changes: Array<ApiDocMetadataChange>;
-  added?: Array<string>;
-  napiVersion?: Array<string>;
-  deprecated?: Array<string>;
-  removed?: Array<string>;
+  /**
+   * A list of changes associated with the entry.
+   */
+  changes: ApiDocMetadataChange[];
+
+  /**
+   * A list of added versions or entities for the entry.
+   */
+  added: string[];
+
+  /**
+   * A list of NAPI (Node API) versions related to the entry.
+   */
+  napiVersion: string[];
+
+  /**
+   * A list of versions where the entry was deprecated.
+   */
+  deprecated: string[];
+
+  /**
+   * A list of versions where the entry was removed.
+   */
+  removed: string[];
 }
 
+/**
+ * Base interface for sections in the API documentation, representing common properties.
+ */
 export interface SectionBase {
+  /**
+   * The type of section (e.g., 'module', 'method', 'property').
+   */
   type: string;
+
+  /**
+   * The name of the section.
+   */
   name: string;
+
+  /**
+   * Raw text content associated with the section.
+   */
   textRaw: string;
+
+  /**
+   * Display name of the section.
+   */
   displayName?: string;
+
+  /**
+   * A detailed description of the section.
+   */
   desc: string;
+
+  /**
+   * A brief description of the section.
+   */
   shortDesc?: string;
+
+  /**
+   * Stability index of the section.
+   */
   stability?: number;
+
+  /**
+   * Descriptive text related to the stability of the section (E.G. "Experimental").
+   */
   stabilityText?: string;
-  meta?: Meta;
+
+  /**
+   * Metadata associated with the section.
+   */
+  meta: Meta;
 }
 
+/**
+ * Represents a module section, which can contain other modules, classes, methods, properties, and other sections.
+ */
 export interface ModuleSection extends SectionBase {
+  /**
+   * The type of section. Always 'module' for this interface.
+   */
   type: 'module';
+
+  /**
+   * Source of the module (File path).
+   */
   source: string;
-  miscs?: Array<MiscSection>;
-  modules?: Array<ModuleSection>;
-  classes?: Array<SignatureSection>;
-  methods?: Array<MethodSignature>;
-  properties?: Array<PropertySection>;
+
+  /**
+   * Miscellaneous sections associated with the module.
+   */
+  miscs?: MiscSection[];
+
+  /**
+   * Submodules within this module.
+   */
+  modules?: ModuleSection[];
+
+  /**
+   * Classes within this module.
+   */
+  classes?: SignatureSection[];
+
+  /**
+   * Methods within this module.
+   */
+  methods?: MethodSignature[];
+
+  /**
+   * Properties within this module.
+   */
+  properties?: PropertySection[];
+
+  /**
+   * Global definitions associated with the module.
+   */
   globals?: ModuleSection | { type: 'global' };
-  signatures?: Array<SignatureSection>;
+
+  /**
+   * Signatures (e.g., functions, methods) associated with this module.
+   */
+  signatures?: SignatureSection[];
 }
 
+/**
+ * Represents a signature section for methods, constructors, or classes.
+ */
 export interface SignatureSection extends SectionBase {
+  /**
+   * The type of section. It can be one of 'class', 'ctor' (constructor), 'classMethod', or 'method'.
+   */
   type: 'class' | 'ctor' | 'classMethod' | 'method';
-  signatures: Array<MethodSignature>;
+
+  /**
+   * A list of method signatures within this section.
+   */
+  signatures: MethodSignature[];
 }
 
+/**
+ * All possible types of sections.
+ */
 export type Section =
   | SignatureSection
   | PropertySection
   | EventSection
   | MiscSection;
 
+/**
+ * Represents a parameter for methods or functions.
+ */
 export interface Parameter {
+  /**
+   * The name of the parameter.
+   */
   name: string;
+
+  /**
+   * Indicates if the parameter is optional.
+   */
   optional?: boolean;
+
+  /**
+   * The default value for the parameter.
+   */
   default?: string;
 }
 
+/**
+ * Represents a method signature, including its parameters and return type.
+ */
 export interface MethodSignature {
-  params: Array<Parameter>;
+  /**
+   * A list of parameters for the method.
+   */
+  params: Parameter[];
+
+  /**
+   * The return type of the method.
+   */
   return?: string;
 }
 
+/**
+ * Represents a property section in the API documentation.
+ */
 export interface PropertySection extends SectionBase {
+  /**
+   * The type of section. Always 'property' for this interface.
+   */
   type: 'property';
+
+  /**
+   * Arbitrary key-value pairs for the property.
+   */
   [key: string]: string | undefined;
 }
 
+/**
+ * Represents an event section, typically containing event parameters.
+ */
 export interface EventSection extends SectionBase {
+  /**
+   * The type of section. Always 'event' for this interface.
+   */
   type: 'event';
-  params: Array<ListItem>;
+
+  /**
+   * A list of parameters associated with the event.
+   */
+  params: ListItem[];
 }
 
+/**
+ * Represents a miscellaneous section with arbitrary content.
+ */
 export interface MiscSection extends SectionBase {
+  /**
+   * The type of section. Always 'misc' for this interface.
+   */
   type: 'misc';
+
   [key: string]: string | undefined;
 }
 
-export interface List {
+/**
+ * Represents a list of parameters.
+ */
+export interface ParameterList {
+  /**
+   * Raw parameter description
+   */
   textRaw: string;
+
+  /**
+   * A short description of the parameter.
+   */
   desc?: string;
+
+  /**
+   * The name of the parameter.
+   */
   name: string;
+
+  /**
+   * The type of the parameter (E.G. string, boolean).
+   */
   type?: string;
+
+  /**
+   * The default value.
+   */
   default?: string;
-  options?: List;
+
+  options?: ParameterList;
 }

--- a/src/generators/legacy-json/types.d.ts
+++ b/src/generators/legacy-json/types.d.ts
@@ -1,0 +1,83 @@
+import { ListItem } from 'mdast';
+
+export interface HierarchizedEntry extends ApiDocMetadataEntry {
+  hierarchyChildren: Array<ApiDocMetadataEntry>;
+}
+
+export interface Meta {
+  changes: Array<ApiDocMetadataChange>;
+  added?: Array<string>;
+  napiVersion?: Array<string>;
+  deprecated?: Array<string>;
+  removed?: Array<string>;
+}
+
+export interface SectionBase {
+  type: string;
+  name: string;
+  textRaw: string;
+  displayName?: string;
+  desc: string;
+  shortDesc?: string;
+  stability?: number;
+  stabilityText?: string;
+  meta?: Meta;
+}
+
+export interface ModuleSection extends SectionBase {
+  type: 'module';
+  source: string;
+  miscs?: Array<MiscSection>;
+  modules?: Array<ModuleSection>;
+  classes?: Array<SignatureSection>;
+  methods?: Array<MethodSignature>;
+  properties?: Array<PropertySection>;
+  globals?: ModuleSection | { type: 'global' };
+  signatures?: Array<SignatureSection>;
+}
+
+export interface SignatureSection extends SectionBase {
+  type: 'class' | 'ctor' | 'classMethod' | 'method';
+  signatures: Array<MethodSignature>;
+}
+
+export type Section =
+  | SignatureSection
+  | PropertySection
+  | EventSection
+  | MiscSection;
+
+export interface Parameter {
+  name: string;
+  optional?: boolean;
+  default?: string;
+}
+
+export interface MethodSignature {
+  params: Array<Parameter>;
+  return?: string;
+}
+
+export interface PropertySection extends SectionBase {
+  type: 'property';
+  [key: string]: string | undefined;
+}
+
+export interface EventSection extends SectionBase {
+  type: 'event';
+  params: Array<ListItem>;
+}
+
+export interface MiscSection extends SectionBase {
+  type: 'misc';
+  [key: string]: string | undefined;
+}
+
+export interface List {
+  textRaw: string;
+  desc?: string;
+  name: string;
+  type?: string;
+  default?: string;
+  options?: List;
+}

--- a/src/generators/legacy-json/utils/buildHierarchy.mjs
+++ b/src/generators/legacy-json/utils/buildHierarchy.mjs
@@ -1,0 +1,78 @@
+/**
+ * Recursively finds the most suitable parent entry for a given `entry` based on heading depth.
+ *
+ * @param {ApiDocMetadataEntry} entry
+ * @param {ApiDocMetadataEntry[]} entry
+ * @param {number} startIdx
+ * @returns {import('../types.d.ts').HierarchizedEntry}
+ */
+function findParent(entry, entries, startIdx) {
+  // Base case: if we're at the beginning of the list, no valid parent exists.
+  if (startIdx < 0) {
+    throw new Error(
+      `Cannot find a suitable parent for entry at index ${startIdx + 1}`
+    );
+  }
+
+  const candidateParent = entries[startIdx];
+  const candidateDepth = candidateParent.heading.depth;
+
+  // If we find a suitable parent, return it.
+  if (candidateDepth < entry.heading.depth) {
+    candidateParent.hierarchyChildren ??= [];
+    return candidateParent;
+  }
+
+  // Recurse upwards to find a suitable parent.
+  return findParent(entry, entries, startIdx - 1);
+}
+
+/**
+ * We need the files to be in a hierarchy based off of depth, but they're
+ *  given to us flattened. So, let's fix that.
+ *
+ * Assuming that {@link entries} is in the same order as the elements are in
+ *  the markdown, we can use the entry's depth property to reassemble the
+ *  hierarchy.
+ *
+ * If depth <= 1, it's a top-level element (aka a root).
+ *
+ * If it's depth is greater than the previous entry's depth, it's a child of
+ *  the previous entry. Otherwise (if it's less than or equal to the previous
+ *  entry's depth), we need to find the entry that it was the greater than. We
+ *  can do this by just looping through entries in reverse starting at the
+ *  current index - 1.
+ *
+ * @param {Array<ApiDocMetadataEntry>} entries
+ * @returns {Array<import('../types.d.ts').HierarchizedEntry>}
+ */
+export function buildHierarchy(entries) {
+  const roots = [];
+
+  // Main loop to construct the hierarchy.
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const currentDepth = entry.heading.depth;
+
+    // Top-level entries are added directly to roots.
+    if (currentDepth <= 1) {
+      roots.push(entry);
+      continue;
+    }
+
+    // For non-root entries, find the appropriate parent.
+    const previousEntry = entries[i - 1];
+    const previousDepth = previousEntry.heading.depth;
+
+    if (currentDepth > previousDepth) {
+      previousEntry.hierarchyChildren ??= [];
+      previousEntry.hierarchyChildren.push(entry);
+    } else {
+      // Use recursive helper to find the nearest valid parent.
+      const parent = findParent(entry, entries, i - 2);
+      parent.hierarchyChildren.push(entry);
+    }
+  }
+
+  return roots;
+}

--- a/src/generators/legacy-json/utils/buildHierarchy.mjs
+++ b/src/generators/legacy-json/utils/buildHierarchy.mjs
@@ -3,6 +3,7 @@
  *
  * @param {ApiDocMetadataEntry} entry
  * @param {ApiDocMetadataEntry[]} entry
+ * @param entries
  * @param {number} startIdx
  * @returns {import('../types.d.ts').HierarchizedEntry}
  */
@@ -29,19 +30,19 @@ function findParent(entry, entries, startIdx) {
 
 /**
  * We need the files to be in a hierarchy based off of depth, but they're
- *  given to us flattened. So, let's fix that.
+ * given to us flattened. So, let's fix that.
  *
  * Assuming that {@link entries} is in the same order as the elements are in
- *  the markdown, we can use the entry's depth property to reassemble the
- *  hierarchy.
+ * the markdown, we can use the entry's depth property to reassemble the
+ * hierarchy.
  *
  * If depth <= 1, it's a top-level element (aka a root).
  *
  * If it's depth is greater than the previous entry's depth, it's a child of
- *  the previous entry. Otherwise (if it's less than or equal to the previous
- *  entry's depth), we need to find the entry that it was the greater than. We
- *  can do this by just looping through entries in reverse starting at the
- *  current index - 1.
+ * the previous entry. Otherwise (if it's less than or equal to the previous
+ * entry's depth), we need to find the entry that it was the greater than. We
+ * can do this by just looping through entries in reverse starting at the
+ * current index - 1.
  *
  * @param {Array<ApiDocMetadataEntry>} entries
  * @returns {Array<import('../types.d.ts').HierarchizedEntry>}

--- a/src/generators/legacy-json/utils/buildHierarchy.mjs
+++ b/src/generators/legacy-json/utils/buildHierarchy.mjs
@@ -2,8 +2,7 @@
  * Recursively finds the most suitable parent entry for a given `entry` based on heading depth.
  *
  * @param {ApiDocMetadataEntry} entry
- * @param {ApiDocMetadataEntry[]} entry
- * @param entries
+ * @param {ApiDocMetadataEntry[]} entries
  * @param {number} startIdx
  * @returns {import('../types.d.ts').HierarchizedEntry}
  */

--- a/src/generators/legacy-json/utils/buildSection.mjs
+++ b/src/generators/legacy-json/utils/buildSection.mjs
@@ -2,22 +2,7 @@ import { buildHierarchy } from './buildHierarchy.mjs';
 import { getRemarkRehype } from '../../../utils/remark.mjs';
 import { transformNodesToString } from '../../../utils/unist.mjs';
 import { parseList } from './parseList.mjs';
-
-const sectionTypePlurals = {
-  module: 'modules',
-  misc: 'miscs',
-  class: 'classes',
-  method: 'methods',
-  property: 'properties',
-  global: 'globals',
-  example: 'examples',
-  ctor: 'signatures',
-  classMethod: 'classMethods',
-  event: 'events',
-  var: 'vars',
-};
-
-const unpromotedKeys = ['textRaw', 'name', 'type', 'desc', 'miscs'];
+import { SECTION_TYPE_PLURALS, UNPROMOTED_KEYS } from '../constants.mjs';
 
 /**
  * Converts a value to an array.
@@ -27,6 +12,9 @@ const unpromotedKeys = ['textRaw', 'name', 'type', 'desc', 'miscs'];
  */
 const enforceArray = val => (Array.isArray(val) ? val : [val]);
 
+/**
+ *
+ */
 export const createSectionBuilder = () => {
   const html = getRemarkRehype();
 
@@ -117,7 +105,7 @@ export const createSectionBuilder = () => {
    * @param {import('../types.d.ts').Section} parent - The parent section.
    */
   const addToParent = (section, parent) => {
-    const key = sectionTypePlurals[section.type] || 'miscs';
+    const key = SECTION_TYPE_PLURALS[section.type] || 'miscs';
 
     parent[key] ??= [];
     parent[key].push(section);
@@ -133,7 +121,7 @@ export const createSectionBuilder = () => {
     if (section.type === 'misc' && parent.type !== 'misc') {
       Object.entries(section).forEach(([key, value]) => {
         // Only promote certain keys
-        if (!unpromotedKeys.includes(key)) {
+        if (!UNPROMOTED_KEYS.includes(key)) {
           // Merge the section's properties into the parent section
           parent[key] = parent[key]
             ? // If the parent already has this key, concatenate the values

--- a/src/generators/legacy-json/utils/buildSection.mjs
+++ b/src/generators/legacy-json/utils/buildSection.mjs
@@ -17,6 +17,8 @@ const sectionTypePlurals = {
   var: 'vars',
 };
 
+const unpromotedKeys = ['textRaw', 'name', 'type', 'desc', 'miscs'];
+
 /**
  * Converts a value to an array.
  * @template T
@@ -25,171 +27,161 @@ const sectionTypePlurals = {
  */
 const enforceArray = val => (Array.isArray(val) ? val : [val]);
 
-/**
- * Creates metadata from a hierarchized entry.
- * @param {import('../types.d.ts').HierarchizedEntry} entry - The entry to create metadata from.
- * @returns {import('../types.d.ts').Meta} The created metadata.
- */
-function createMeta(entry) {
-  const {
+export const createSectionBuilder = () => {
+  const html = getRemarkRehype();
+
+  /**
+   * Creates metadata from a hierarchized entry.
+   * @param {import('../types.d.ts').HierarchizedEntry} entry - The entry to create metadata from.
+   * @returns {import('../types.d.ts').Meta} The created metadata.
+   */
+  const createMeta = ({
     added_in = [],
     n_api_version = [],
     deprecated_in = [],
     removed_in = [],
     changes,
-  } = entry;
-
-  return {
+  }) => ({
     changes,
     added: enforceArray(added_in),
     napiVersion: enforceArray(n_api_version),
     deprecated: enforceArray(deprecated_in),
     removed: enforceArray(removed_in),
-  };
-}
+  });
 
-/**
- * Creates a section from an entry and its heading.
- * @param {import('../types.d.ts').HierarchizedEntry} entry - The AST entry.
- * @param {HeadingMetadataParent} head - The head node of the entry.
- * @returns {import('../types.d.ts').Section} The created section.
- */
-function createSection(entry, head) {
-  return {
+  /**
+   * Creates a section from an entry and its heading.
+   * @param {import('../types.d.ts').HierarchizedEntry} entry - The AST entry.
+   * @param {HeadingMetadataParent} head - The head node of the entry.
+   * @returns {import('../types.d.ts').Section} The created section.
+   */
+  const createSection = (entry, head) => ({
     textRaw: transformNodesToString(head.children),
     name: head.data.name,
     type: head.data.type,
     meta: createMeta(entry),
     introduced_in: entry.introduced_in,
-  };
-}
+  });
 
-/**
- * Parses stability metadata and adds it to the section.
- * @param {import('../types.d.ts').Section} section - The section to add stability to.
- * @param {Array} nodes - The AST nodes.
- * @param {import('../types.d.ts').HierarchizedEntry} entry - The entry to handle.
- */
-function parseStability(section, nodes, entry) {
-  const json = entry.stability.toJSON()[0];
-  if (json) {
-    section.stability = json.index;
-    section.stabilityText = json.description;
-    nodes.splice(0, 1);
-  }
-}
+  /**
+   * Parses stability metadata and adds it to the section.
+   * @param {import('../types.d.ts').Section} section - The section to update.
+   * @param {Array} nodes - The remaining AST nodes.
+   * @param {import('../types.d.ts').HierarchizedEntry} entry - The entry providing stability information.
+   */
+  const parseStability = (section, nodes, { stability }) => {
+    const stabilityInfo = stability.toJSON()?.[0];
 
-let lazyHTML;
-
-/**
- * Adds a description to the section.
- * @param {import('../types.d.ts').Section} section - The section to add description to.
- * @param {Array} nodes - The AST nodes.
- */
-function addDescription(section, nodes) {
-  if (!nodes.length) {
-    return;
-  }
-
-  if (section.desc) {
-    section.shortDesc = section.desc;
-  }
-
-  lazyHTML ??= getRemarkRehype();
-
-  const rendered = lazyHTML.stringify(
-    lazyHTML.runSync({ type: 'root', children: nodes })
-  );
-
-  section.desc = rendered || undefined;
-}
-
-/**
- * Adds additional metadata to the section based on its type.
- * @param {import('../types.d.ts').Section} section - The section to update.
- * @param {import('../types.d.ts').Section} parentSection - The parent section.
- * @param {import('../../types.d.ts').NodeWithData} headingNode - The heading node.
- */
-function addAdditionalMetadata(section, parentSection, headingNode) {
-  if (!section.type) {
-    section.name = section.textRaw.toLowerCase().trim().replace(/\s+/g, '_');
-    section.displayName = headingNode.data.name;
-    section.type = parentSection.type === 'misc' ? 'misc' : 'module';
-  }
-}
-
-/**
- * Adds the section to its parent section.
- * @param {import('../types.d.ts').Section} section - The section to add.
- * @param {import('../types.d.ts').Section} parentSection - The parent section.
- */
-function addToParent(section, parentSection) {
-  const pluralType = sectionTypePlurals[section.type];
-
-  parentSection[pluralType] = parentSection[pluralType] || [];
-  parentSection[pluralType].push(section);
-}
-
-const notTransferredKeys = ['textRaw', 'name', 'type', 'desc', 'miscs'];
-
-/**
- * Promotes children properties to the parent level if the section type is 'misc'.
- *
- * @param {import('../types.d.ts').Section} section - The section to promote.
- * @param {import('../types.d.ts').Section} parentSection - The parent section.
- */
-const makeChildrenTopLevelIfMisc = (section, parentSection) => {
-  // Only promote if the current section is of type 'misc' and the parent is not 'misc'
-  if (section.type === 'misc' && parentSection.type !== 'misc') {
-    Object.entries(section).forEach(([key, value]) => {
-      // Skip keys that should not be transferred
-      if (notTransferredKeys.includes(key)) return;
-
-      // Merge the section's properties into the parent section
-      parentSection[key] = parentSection[key]
-        ? // If the parent already has this key, concatenate the values
-          [].concat(parentSection[key], value)
-        : // Otherwise, directly assign the section's value to the parent
-          value;
-    });
-  }
-};
-
-const handleChildren = (entry, section) => {
-  entry.hierarchyChildren?.forEach(child => handleEntry(child, section));
-};
-
-/**
- * Handles an entry and updates the parent section.
- * @param {import('../types.d.ts').HierarchizedEntry} entry - The entry to handle.
- * @param {import('../types.d.ts').Section} parentSection - The parent section.
- */
-function handleEntry(entry, parentSection) {
-  const [headingNode, ...nodes] = structuredClone(entry.content.children);
-  const section = createSection(entry, headingNode);
-
-  parseStability(section, nodes, entry);
-  parseList(section, nodes);
-  addDescription(section, nodes);
-  handleChildren(entry, section);
-  addAdditionalMetadata(section, parentSection, headingNode);
-  addToParent(section, parentSection);
-  makeChildrenTopLevelIfMisc(section, parentSection);
-}
-
-/**
- * Builds the module section from head and entries.
- * @param {ApiDocMetadataEntry} head - The head metadata entry.
- * @param {Array<ApiDocMetadataEntry>} entries - The list of metadata entries.
- * @returns {import('../types.d.ts').ModuleSection} The constructed module section.
- */
-export default (head, entries) => {
-  const rootModule = {
-    type: 'module',
-    source: head.api_doc_source,
+    if (stabilityInfo) {
+      section.stability = stabilityInfo.index;
+      section.stabilityText = stabilityInfo.description;
+      nodes.shift(); // Remove stability node from processing
+    }
   };
 
-  buildHierarchy(entries).forEach(entry => handleEntry(entry, rootModule));
+  /**
+   * Adds a description to the section.
+   * @param {import('../types.d.ts').Section} section - The section to update.
+   * @param {Array} nodes - The remaining AST nodes.
+   */
+  const addDescription = (section, nodes) => {
+    if (!nodes.length) {
+      return;
+    }
 
-  return rootModule;
+    const rendered = html.stringify(
+      html.runSync({ type: 'root', children: nodes })
+    );
+
+    section.shortDesc = section.desc || undefined;
+    section.desc = rendered || undefined;
+  };
+
+  /**
+   * Adds additional metadata to the section based on its type.
+   * @param {import('../types.d.ts').Section} section - The section to update.
+   * @param {import('../types.d.ts').Section} parent - The parent section.
+   * @param {import('../../types.d.ts').NodeWithData} heading - The heading node of the section.
+   */
+  const addAdditionalMetadata = (section, parent, heading) => {
+    if (!section.type) {
+      section.name = section.textRaw.toLowerCase().trim().replace(/\s+/g, '_');
+      section.displayName = heading.data.name;
+      section.type = parent.type === 'misc' ? 'misc' : 'module';
+    }
+  };
+
+  /**
+   * Adds the section to its parent section.
+   * @param {import('../types.d.ts').Section} section - The section to add.
+   * @param {import('../types.d.ts').Section} parent - The parent section.
+   */
+  const addToParent = (section, parent) => {
+    const key = sectionTypePlurals[section.type] || 'miscs';
+
+    parent[key] ??= [];
+    parent[key].push(section);
+  };
+
+  /**
+   * Promotes children properties to the parent level if the section type is 'misc'.
+   * @param {import('../types.d.ts').Section} section - The section to promote.
+   * @param {import('../types.d.ts').Section} parent - The parent section.
+   */
+  const promoteMiscChildren = (section, parent) => {
+    // Only promote if the current section is of type 'misc' and the parent is not 'misc'
+    if (section.type === 'misc' && parent.type !== 'misc') {
+      Object.entries(section).forEach(([key, value]) => {
+        // Only promote certain keys
+        if (!unpromotedKeys.includes(key)) {
+          // Merge the section's properties into the parent section
+          parent[key] = parent[key]
+            ? // If the parent already has this key, concatenate the values
+              [].concat(parent[key], value)
+            : // Otherwise, directly assign the section's value to the parent
+              [];
+        }
+      });
+    }
+  };
+
+  /**
+   * Processes children of a given entry and updates the section.
+   * @param {import('../types.d.ts').HierarchizedEntry} entry - The current entry.
+   * @param {import('../types.d.ts').Section} section - The current section.
+   */
+  const handleChildren = ({ hierarchyChildren }, section) =>
+    hierarchyChildren?.forEach(child => handleEntry(child, section));
+
+  /**
+   * Handles an entry and updates the parent section.
+   * @param {import('../types.d.ts').HierarchizedEntry} entry - The entry to process.
+   * @param {import('../types.d.ts').Section} parent - The parent section.
+   */
+  const handleEntry = (entry, parent) => {
+    const [headingNode, ...nodes] = structuredClone(entry.content.children);
+    const section = createSection(entry, headingNode);
+
+    parseStability(section, nodes, entry);
+    parseList(section, nodes);
+    addDescription(section, nodes);
+    handleChildren(entry, section);
+    addAdditionalMetadata(section, parent, headingNode);
+    addToParent(section, parent);
+    promoteMiscChildren(section, parent);
+  };
+
+  /**
+   * Builds the module section from head metadata and entries.
+   * @param {ApiDocMetadataEntry} head - The head metadata entry.
+   * @param {Array<ApiDocMetadataEntry>} entries - The list of metadata entries.
+   * @returns {import('../types.d.ts').ModuleSection} The constructed module section.
+   */
+  return (head, entries) => {
+    const rootModule = { type: 'module', source: head.api_doc_source };
+
+    buildHierarchy(entries).forEach(entry => handleEntry(entry, rootModule));
+
+    return rootModule;
+  };
 };

--- a/src/generators/legacy-json/utils/buildSection.mjs
+++ b/src/generators/legacy-json/utils/buildSection.mjs
@@ -1,0 +1,314 @@
+import {
+  DEFAULT_EXPRESSION,
+  LEADING_HYPHEN,
+  NAME_EXPRESSION,
+  RETURN_EXPRESSION,
+  TYPE_EXPRESSION,
+} from '../constants.mjs';
+import { buildHierarchy } from './buildHierarchy.mjs';
+import parseSignature from './parseSignature.mjs';
+import { getRemarkRehype } from '../../../utils/remark.mjs';
+import { transformNodesToString } from '../../../utils/unist.mjs';
+
+const sectionTypePlurals = {
+  module: 'modules',
+  misc: 'miscs',
+  class: 'classes',
+  method: 'methods',
+  property: 'properties',
+  global: 'globals',
+  example: 'examples',
+  ctor: 'signatures',
+  classMethod: 'classMethods',
+  event: 'events',
+  var: 'vars',
+};
+
+/**
+ * Converts a value to an array.
+ * @template T
+ * @param {T | T[]} val - The value to convert.
+ * @returns {T[]} The value as an array.
+ */
+const enforceArray = val => (Array.isArray(val) ? val : [val]);
+
+/**
+ * Creates metadata from a hierarchized entry.
+ * @param {import('../types.d.ts').HierarchizedEntry} entry - The entry to create metadata from.
+ * @returns {import('../types.d.ts').Meta} The created metadata.
+ */
+function createMeta(entry) {
+  const {
+    added_in = [],
+    n_api_version = [],
+    deprecated_in = [],
+    removed_in = [],
+    changes,
+  } = entry;
+
+  return {
+    changes,
+    added: enforceArray(added_in),
+    napiVersion: enforceArray(n_api_version),
+    deprecated: enforceArray(deprecated_in),
+    removed: enforceArray(removed_in),
+  };
+}
+
+/**
+ * Creates a section from an entry and its heading.
+ * @param {import('../types.d.ts').HierarchizedEntry} entry - The AST entry.
+ * @param {HeadingMetadataParent} head - The head node of the entry.
+ * @returns {import('../types.d.ts').Section} The created section.
+ */
+function createSection(entry, head) {
+  return {
+    textRaw: transformNodesToString(head.children),
+    name: head.data.name,
+    type: head.data.type,
+    meta: createMeta(entry),
+    introduced_in: entry.introduced_in,
+  };
+}
+
+/**
+ * Parses a list item to extract properties.
+ * @param {import('mdast').ListItem} child - The list item node.
+ * @param {import('../types.d.ts').HierarchizedEntry} entry - The entry containing raw content.
+ * @returns {import('../types.d.ts').List} The parsed list.
+ */
+function parseListItem(child, entry) {
+  const current = {};
+
+  /**
+   * Extracts raw content from a node based on its position.
+   * @param {import('mdast').BlockContent} node
+   * @returns {string}
+   */
+  const getRawContent = node =>
+    entry.rawContent.slice(
+      node.position.start.offset,
+      node.position.end.offset
+    );
+
+  /**
+   * Extracts a pattern from text and assigns it to the current object.
+   * @param {string} text
+   * @param {RegExp} pattern
+   * @param {string} key
+   * @returns {string}
+   */
+  const extractPattern = (text, pattern, key) => {
+    const [, match] = text.match(pattern) || [];
+    if (match) {
+      current[key] = match.trim().replace(/\.$/, '');
+      return text.replace(pattern, '');
+    }
+    return text;
+  };
+
+  // Combine and clean text from child nodes, excluding nested lists
+  current.textRaw = child.children
+    .filter(node => node.type !== 'list')
+    .map(getRawContent)
+    .join('')
+    .replace(/\s+/g, ' ')
+    .replace(/<!--.*?-->/gs, '');
+
+  let text = current.textRaw;
+
+  // Determine if the current item is a return statement
+  if (RETURN_EXPRESSION.test(text)) {
+    current.name = 'return';
+    text = text.replace(RETURN_EXPRESSION, '');
+  } else {
+    text = extractPattern(text, NAME_EXPRESSION, 'name');
+  }
+
+  // Extract type and default values if present
+  text = extractPattern(text, TYPE_EXPRESSION, 'type');
+  text = extractPattern(text, DEFAULT_EXPRESSION, 'default');
+
+  // Assign the remaining text as the description after removing leading hyphens
+  current.desc = text.replace(LEADING_HYPHEN, '').trim() || undefined;
+
+  // Recursively parse nested options if a list is found within the list item
+  const optionsNode = child.children.find(child => child.type === 'list');
+  if (optionsNode) {
+    current.options = optionsNode.children.map(child =>
+      parseListItem(child, entry)
+    );
+  }
+
+  return current;
+}
+
+/**
+ * Parses stability metadata and adds it to the section.
+ * @param {import('../types.d.ts').Section} section - The section to add stability to.
+ * @param {Array} nodes - The AST nodes.
+ */
+function parseStability(section, nodes) {
+  nodes.forEach((node, i) => {
+    if (
+      node.type === 'blockquote' &&
+      node.children.length === 1 &&
+      node.children[0].type === 'paragraph' &&
+      nodes.slice(0, i).every(n => n.type === 'list')
+    ) {
+      const text = transformNodesToString(node.children[0].children);
+      const stabilityMatch = /^Stability: ([0-5])(?:\s*-\s*)?(.*)$/s.exec(text);
+      if (stabilityMatch) {
+        section.stability = Number(stabilityMatch[1]);
+        section.stabilityText = stabilityMatch[2].replace(/\n/g, ' ').trim();
+        nodes.splice(i, 1); // Remove the matched stability node to prevent further processing
+      }
+    }
+  });
+}
+
+/**
+ * Parses a list and updates the section accordingly.
+ * @param {import('../types.d.ts').Section} section - The section to update.
+ * @param {Array} nodes - The AST nodes.
+ * @param {import('../types.d.ts').HierarchizedEntry} entry - The associated entry.
+ */
+function parseList(section, nodes, entry) {
+  const list = nodes[0]?.type === 'list' ? nodes.shift() : null;
+  const values = list
+    ? list.children.map(child => parseListItem(child, entry))
+    : [];
+
+  switch (section.type) {
+    case 'ctor':
+    case 'classMethod':
+    case 'method':
+      section.signatures = [parseSignature(section.textRaw, values)];
+      break;
+    case 'property':
+      if (values.length) {
+        const { type, ...rest } = values[0];
+        if (type) section.propertySigType = type;
+        Object.assign(section, rest);
+        section.textRaw = `\`${section.name}\` ${section.textRaw}`;
+      }
+      break;
+    case 'event':
+      section.params = values;
+      break;
+    default:
+      if (list) nodes.unshift(list); // If the list wasn't processed, add it back for further processing
+  }
+}
+
+/**
+ * Adds a description to the section.
+ * @param {import('../types.d.ts').Section} section - The section to add description to.
+ * @param {Array} nodes - The AST nodes.
+ */
+function addDescription(section, nodes) {
+  if (!nodes.length) return;
+
+  if (section.desc) {
+    section.shortDesc = section.desc;
+  }
+
+  const html = getRemarkRehype();
+  const rendered = html.stringify(
+    html.runSync({ type: 'root', children: nodes })
+  );
+  section.desc = rendered || undefined;
+}
+
+/**
+ * Adds additional metadata to the section based on its type.
+ * @param {import('../types.d.ts').Section} section - The section to update.
+ * @param {import('../types.d.ts').Section} parentSection - The parent section.
+ * @param {import('../../types.d.ts').NodeWithData} headingNode - The heading node.
+ */
+function addAdditionalMetadata(section, parentSection, headingNode) {
+  if (!section.type) {
+    section.name = section.textRaw.toLowerCase().trim().replace(/\s+/g, '_');
+    section.displayName = headingNode.data.name;
+    section.type = parentSection.type === 'misc' ? 'misc' : 'module';
+  }
+}
+
+/**
+ * Adds the section to its parent section.
+ * @param {import('../types.d.ts').Section} section - The section to add.
+ * @param {import('../types.d.ts').Section} parentSection - The parent section.
+ */
+function addToParent(section, parentSection) {
+  const pluralType = sectionTypePlurals[section.type];
+  parentSection[pluralType] = parentSection[pluralType] || [];
+  parentSection[pluralType].push(section);
+}
+
+/**
+ * Promotes children to top-level if the section type is 'misc'.
+ * @param {import('../types.d.ts').Section} section - The section to promote.
+ * @param {import('../types.d.ts').Section} parentSection - The parent section.
+ */
+const makeChildrenTopLevelIfMisc = (section, parentSection) => {
+  if (section.type !== 'misc' || parentSection.type === 'misc') {
+    return;
+  }
+
+  Object.keys(section).forEach(key => {
+    if (['textRaw', 'name', 'type', 'desc', 'miscs'].includes(key)) {
+      return;
+    }
+    if (parentSection[key]) {
+      parentSection[key] = Array.isArray(parentSection[key])
+        ? parentSection[key].concat(section[key])
+        : section[key];
+    } else {
+      parentSection[key] = section[key];
+    }
+  });
+};
+
+/**
+ * Handles an entry and updates the parent section.
+ * @param {import('../types.d.ts').HierarchizedEntry} entry - The entry to handle.
+ * @param {import('../types.d.ts').Section} parentSection - The parent section.
+ */
+function handleEntry(entry, parentSection) {
+  const [headingNode, ...nodes] = structuredClone(entry.content.children);
+  const section = createSection(entry, headingNode);
+
+  parseStability(section, nodes);
+  parseList(section, nodes, entry);
+  addDescription(section, nodes);
+  entry.hierarchyChildren?.forEach(child => handleEntry(child, section));
+  addAdditionalMetadata(section, parentSection, headingNode);
+  addToParent(section, parentSection);
+  makeChildrenTopLevelIfMisc(section, parentSection);
+
+  if (section.type === 'property') {
+    if (section.propertySigType) {
+      section.type = section.propertySigType;
+      delete section.propertySigType;
+    } else {
+      delete section.type;
+    }
+  }
+}
+
+/**
+ * Builds the module section from head and entries.
+ * @param {ApiDocMetadataEntry} head - The head metadata entry.
+ * @param {Array<ApiDocMetadataEntry>} entries - The list of metadata entries.
+ * @returns {import('../types.d.ts').ModuleSection} The constructed module section.
+ */
+export default (head, entries) => {
+  const rootModule = {
+    type: 'module',
+    source: head.api_doc_source,
+  };
+
+  buildHierarchy(entries).forEach(entry => handleEntry(entry, rootModule));
+
+  return rootModule;
+};

--- a/src/generators/legacy-json/utils/buildSection.mjs
+++ b/src/generators/legacy-json/utils/buildSection.mjs
@@ -1,14 +1,7 @@
-import {
-  DEFAULT_EXPRESSION,
-  LEADING_HYPHEN,
-  NAME_EXPRESSION,
-  RETURN_EXPRESSION,
-  TYPE_EXPRESSION,
-} from '../constants.mjs';
 import { buildHierarchy } from './buildHierarchy.mjs';
-import parseSignature from './parseSignature.mjs';
 import { getRemarkRehype } from '../../../utils/remark.mjs';
 import { transformNodesToString } from '../../../utils/unist.mjs';
+import { parseList } from './parseList.mjs';
 
 const sectionTypePlurals = {
   module: 'modules',
@@ -72,77 +65,6 @@ function createSection(entry, head) {
 }
 
 /**
- *
- * @param {String} string
- * @returns {String}
- */
-function transformTypeReferences(string) {
-  // console.log(string)
-  return string.replaceAll(/`<([^>]+)>`/g, '{$1}').replaceAll('} | {', '|');
-}
-
-/**
- * Parses a list item to extract properties.
- * @param {import('mdast').ListItem} child - The list item node.
- * @returns {import('../types.d.ts').List} The parsed list.
- */
-function parseListItem(child) {
-  const current = {};
-
-  /**
-   * Extracts a pattern from text and assigns it to the current object.
-   * @param {string} text
-   * @param {RegExp} pattern
-   * @param {string} key
-   * @returns {string}
-   */
-  const extractPattern = (text, pattern, key) => {
-    const [, match] = text.match(pattern) || [];
-    if (match) {
-      current[key] = match.trim().replace(/\.$/, '');
-      return text.replace(pattern, '');
-    }
-    return text;
-  };
-
-  // Combine and clean text from child nodes, excluding nested lists
-  current.textRaw = transformTypeReferences(
-    transformNodesToString(
-      child.children.filter(node => node.type !== 'list'),
-      true
-    )
-      .replace(/\s+/g, ' ')
-      .replace(/<!--.*?-->/gs, '')
-  );
-
-  let text = current.textRaw;
-
-  // Determine if the current item is a return statement
-  if (RETURN_EXPRESSION.test(text)) {
-    current.name = 'return';
-    text = text.replace(RETURN_EXPRESSION, '');
-  } else {
-    text = extractPattern(text, NAME_EXPRESSION, 'name');
-  }
-
-  // Extract type and default values if present
-  text = extractPattern(text, TYPE_EXPRESSION, 'type');
-  text = extractPattern(text, DEFAULT_EXPRESSION, 'default');
-
-  // Assign the remaining text as the description after removing leading hyphens
-  current.desc = text.replace(LEADING_HYPHEN, '').trim() || undefined;
-
-  // Recursively parse nested options if a list is found within the list item
-  const optionsNode = child.children.find(child => child.type === 'list');
-
-  if (optionsNode) {
-    current.options = optionsNode.children.map(parseListItem);
-  }
-
-  return current;
-}
-
-/**
  * Parses stability metadata and adds it to the section.
  * @param {import('../types.d.ts').Section} section - The section to add stability to.
  * @param {Array} nodes - The AST nodes.
@@ -154,42 +76,6 @@ function parseStability(section, nodes, entry) {
     section.stability = json.index;
     section.stabilityText = json.description;
     nodes.splice(0, 1);
-  }
-}
-
-/**
- * Parses a list and updates the section accordingly.
- * @param {import('../types.d.ts').Section} section - The section to update.
- * @param {Array} nodes - The AST nodes.
- */
-function parseList(section, nodes) {
-  const list = nodes[0]?.type === 'list' ? nodes.shift() : null;
-
-  const values = list ? list.children.map(parseListItem) : [];
-
-  switch (section.type) {
-    case 'ctor':
-    case 'classMethod':
-    case 'method':
-      section.signatures = [parseSignature(section.textRaw, values)];
-      break;
-    case 'property':
-      if (values.length) {
-        const { type, ...rest } = values[0];
-
-        section.type = type;
-        Object.assign(section, rest);
-        section.textRaw = `\`${section.name}\` ${section.textRaw}`;
-      }
-      break;
-    case 'event':
-      section.params = values;
-      break;
-    default:
-      // If the list wasn't processed, add it back for further processing
-      if (list) {
-        nodes.unshift(list);
-      }
   }
 }
 

--- a/src/generators/legacy-json/utils/parseList.mjs
+++ b/src/generators/legacy-json/utils/parseList.mjs
@@ -1,0 +1,114 @@
+import {
+  DEFAULT_EXPRESSION,
+  LEADING_HYPHEN,
+  NAME_EXPRESSION,
+  RETURN_EXPRESSION,
+  TYPE_EXPRESSION,
+} from '../constants.mjs';
+import parseSignature from './parseSignature.mjs';
+import { transformNodesToString } from '../../../utils/unist.mjs';
+
+/**
+ * Transforms type references in a string by replacing template syntax with curly braces and cleaning up.
+ * @param {String} string
+ * @returns {String}
+ */
+function transformTypeReferences(string) {
+  return string.replace(/`<([^>]+)>`/g, '{$1}').replaceAll('} | {', '|');
+}
+
+/**
+ * Extracts a matching pattern from a text and assigns it to the current object.
+ * @param {string} text
+ * @param {RegExp} pattern
+ * @param {string} key
+ * @param {Object} current
+ * @returns {string}
+ */
+const extractPattern = (text, pattern, key, current) => {
+  const match = text.match(pattern)?.[1]?.trim().replace(/\.$/, '');
+  if (match) {
+    current[key] = match;
+    return text.replace(pattern, '');
+  }
+  return text;
+};
+
+/**
+ * Parses a list item node to extract key properties.
+ * @param {import('mdast').ListItem} child - The list item node.
+ * @returns {import('../types').ParameterList} The parsed list item.
+ */
+function parseListItem(child) {
+  const current = {};
+
+  // Clean up and transform the raw text
+  current.textRaw = transformTypeReferences(
+    transformNodesToString(
+      child.children.filter(node => node.type !== 'list'),
+      true
+    )
+      .replace(/\s+/g, ' ')
+      .replace(/<!--.*?-->/gs, '')
+  );
+
+  let text = current.textRaw;
+
+  // Determine the item type and extract relevant details
+  if (RETURN_EXPRESSION.test(text)) {
+    current.name = 'return';
+    text = text.replace(RETURN_EXPRESSION, '');
+  } else {
+    text = extractPattern(text, NAME_EXPRESSION, 'name', current);
+  }
+
+  text = extractPattern(text, TYPE_EXPRESSION, 'type', current);
+  text = extractPattern(text, DEFAULT_EXPRESSION, 'default', current);
+
+  // Assign the remaining text as description after removing any leading hyphen
+  current.desc = text.replace(LEADING_HYPHEN, '').trim() || undefined;
+
+  // Recursively parse nested options if a list exists
+  const optionsNode = child.children.find(node => node.type === 'list');
+  if (optionsNode) {
+    current.options = optionsNode.children.map(parseListItem);
+  }
+
+  return current;
+}
+
+/**
+ * Parses a list of nodes and updates the section accordingly.
+ * @param {import('../types').Section} section - The section to update.
+ * @param {Array} nodes - The AST nodes.
+ */
+export function parseList(section, nodes) {
+  const list = nodes[0]?.type === 'list' ? nodes.shift() : null;
+
+  const values = list ? list.children.map(parseListItem) : [];
+
+  // Handle different section types based on parsed values
+  switch (section.type) {
+    case 'ctor':
+    case 'classMethod':
+    case 'method':
+      section.signatures = [parseSignature(section.textRaw, values)];
+      break;
+    case 'property':
+      if (values.length) {
+        const { type, ...rest } = values[0];
+        section.type = type;
+        Object.assign(section, rest);
+        section.textRaw = `\`${section.name}\` ${section.textRaw}`;
+      }
+      break;
+    case 'event':
+      section.params = values;
+      break;
+    default:
+      // Re-add list for further processing if not handled
+      if (list) {
+        nodes.unshift(list);
+      }
+  }
+}

--- a/src/generators/legacy-json/utils/parseSignature.mjs
+++ b/src/generators/legacy-json/utils/parseSignature.mjs
@@ -108,8 +108,7 @@ function findParameter(parameterName, index, markdownParameters) {
 
 /**
  * @param {string[]} declaredParameters
- * @param {Array<import('../types.d.ts').ParameterList>} parameters
- * @param markdownParameters
+ * @param {Array<import('../types.d.ts').ParameterList>} markdownParameters
  */
 function parseParameters(declaredParameters, markdownParameters) {
   /**

--- a/src/generators/legacy-json/utils/parseSignature.mjs
+++ b/src/generators/legacy-json/utils/parseSignature.mjs
@@ -77,7 +77,7 @@ function parseDefaultValue(parameterName) {
 /**
  * @param {string} parameterName
  * @param {number} index
- * @param {Array<import('../types.d.ts').List>} markdownParameters
+ * @param {Array<import('../types.d.ts').ParameterList>} markdownParameters
  * @returns {import('../types.d.ts').Parameter}
  */
 function findParameter(parameterName, index, markdownParameters) {
@@ -108,7 +108,7 @@ function findParameter(parameterName, index, markdownParameters) {
 
 /**
  * @param {string[]} declaredParameters
- * @param {Array<import('../types.d.ts').List>} parameters
+ * @param {Array<import('../types.d.ts').ParameterList>} parameters
  */
 function parseParameters(declaredParameters, markdownParameters) {
   /**
@@ -165,7 +165,7 @@ function parseParameters(declaredParameters, markdownParameters) {
 
 /**
  * @param {string} textRaw Something like `new buffer.Blob([sources[, options]])`
- * @param {Array<import('../types.d.ts').List} markdownParameters The properties in the AST
+ * @param {Array<import('../types.d.ts').ParameterList} markdownParameters The properties in the AST
  * @returns {import('../types.d.ts').MethodSignature | undefined}
  */
 export default (textRaw, markdownParameters) => {

--- a/src/generators/legacy-json/utils/parseSignature.mjs
+++ b/src/generators/legacy-json/utils/parseSignature.mjs
@@ -109,6 +109,7 @@ function findParameter(parameterName, index, markdownParameters) {
 /**
  * @param {string[]} declaredParameters
  * @param {Array<import('../types.d.ts').ParameterList>} parameters
+ * @param markdownParameters
  */
 function parseParameters(declaredParameters, markdownParameters) {
   /**

--- a/src/generators/legacy-json/utils/parseSignature.mjs
+++ b/src/generators/legacy-json/utils/parseSignature.mjs
@@ -1,0 +1,206 @@
+'use strict';
+
+import { PARAM_EXPRESSION } from '../constants.mjs';
+
+const OPTIONAL_LEVEL_CHANGES = { '[': 1, ']': -1, ' ': 0 };
+
+/**
+ * @param {string} parameterName
+ * @param {number} optionalDepth
+ * @returns {[string, number, boolean]}
+ */
+function parseNameAndOptionalStatus(parameterName, optionalDepth) {
+  // Let's check if the parameter is optional & grab its name at the same time.
+  //  We need to see if there's any leading brackets in front of the parameter
+  //  name. While we're doing that, we can also get the index where the
+  //  parameter's name actually starts at.
+  let startingIdx = 0;
+  for (; startingIdx < parameterName.length; startingIdx++) {
+    const levelChange = OPTIONAL_LEVEL_CHANGES[parameterName[startingIdx]];
+
+    if (!levelChange) {
+      break;
+    }
+
+    optionalDepth += levelChange;
+  }
+
+  const isParameterOptional = optionalDepth > 0;
+
+  // Now let's check for any trailing brackets at the end of the parameter's
+  //  name. This will tell us where the parameter's name ends.
+  let endingIdx = parameterName.length - 1;
+  for (; endingIdx >= 0; endingIdx--) {
+    const levelChange = OPTIONAL_LEVEL_CHANGES[parameterName[endingIdx]];
+    if (!levelChange) {
+      break;
+    }
+
+    optionalDepth += levelChange;
+  }
+
+  return [
+    parameterName.substring(startingIdx, endingIdx + 1),
+    optionalDepth,
+    isParameterOptional,
+  ];
+}
+
+/**
+ * @param {string} parameterName
+ * @returns {[string, string | undefined]}
+ */
+function parseDefaultValue(parameterName) {
+  /**
+   * @type {string | undefined}
+   */
+  let defaultValue;
+
+  const equalSignPos = parameterName.indexOf('=');
+  if (equalSignPos !== -1) {
+    // We do have a default value, let's extract it
+    defaultValue = parameterName.substring(equalSignPos).trim();
+
+    // Let's remove the default value from the parameter name
+    parameterName = parameterName.substring(0, equalSignPos);
+  }
+
+  return [parameterName, defaultValue];
+}
+
+/**
+ * @param {string} parameterName
+ * @param {number} index
+ * @param {Array<import('../types.d.ts').List>} markdownParameters
+ * @returns {import('../types.d.ts').Parameter}
+ */
+function findParameter(parameterName, index, markdownParameters) {
+  let parameter = markdownParameters[index];
+  if (parameter && parameter.name === parameterName) {
+    return parameter;
+  }
+
+  // Method likely has multiple signatures, something like
+  //  `new Console(stdout[, stderr][, ignoreErrors])` and `new Console(options)`
+  // Try to find the parameter that this is being shared with
+  for (const markdownProperty of markdownParameters) {
+    if (markdownProperty.name === parameterName) {
+      // Found it
+      return markdownParameters;
+    } else if (markdownProperty.options) {
+      for (const option of markdownProperty.options) {
+        if (option.name === parameterName) {
+          // Found a matching one in the parameter's options
+          return Object.assign({}, option);
+        }
+      }
+    }
+  }
+
+  // At this point, we couldn't find a shared signature
+  if (parameterName.startsWith('...')) {
+    return { name: parameterName };
+  } else {
+    throw new Error(`Invalid param "${parameterName}"`);
+  }
+}
+
+/**
+ * @param {string[]} declaredParameters
+ * @param {Array<import('../types.d.ts').List>} parameters
+ */
+function parseParameters(declaredParameters, markdownParameters) {
+  /**
+   * @type {Array<import('../types.d.ts').Parameter>}
+   */
+  let parameters = [];
+
+  let optionalDepth = 0;
+
+  declaredParameters.forEach((parameterName, i) => {
+    /**
+     * @example 'length]]'
+     * @example 'arrayBuffer['
+     * @example '[sources['
+     * @example 'end'
+     */
+    parameterName = parameterName.trim();
+
+    // We need to do three things here:
+    //  1. Determine the declared parameters' name
+    //  2. Determine if the parameter is optional
+    //  3. Determine if the parameter has a default value
+
+    /**
+     * This will handle the first and second thing for us
+     * @type {boolean}
+     */
+    let isParameterOptional;
+    [parameterName, optionalDepth, isParameterOptional] =
+      parseNameAndOptionalStatus(parameterName, optionalDepth);
+
+    /**
+     * Now let's work on the third thing
+     * @type {string | undefined}
+     */
+    let defaultValue;
+    [parameterName, defaultValue] = parseDefaultValue(parameterName);
+
+    const parameter = findParameter(parameterName, i, markdownParameters);
+
+    if (isParameterOptional) {
+      parameter.optional = true;
+    }
+
+    if (defaultValue) {
+      parameter.default = defaultValue;
+    }
+
+    parameters.push(parameter);
+  });
+
+  return parameters;
+}
+
+/**
+ * @param {string} textRaw Something like `new buffer.Blob([sources[, options]])`
+ * @param {Array<import('../types.d.ts').List} markdownParameters The properties in the AST
+ * @returns {import('../types.d.ts').MethodSignature | undefined}
+ */
+export default (textRaw, markdownParameters) => {
+  /**
+   * @type {import('../types.d.ts').MethodSignature}
+   */
+  const signature = { params: [] };
+
+  // Find the return value & filter it out
+  markdownParameters = markdownParameters.filter(value => {
+    if (value.name === 'return') {
+      signature.return = value;
+      return false;
+    }
+
+    return true;
+  });
+
+  /**
+   * Extract the parameters from the method's declaration
+   * @example `[sources[, options]]`
+   */
+  let [, declaredParameters] =
+    textRaw.substring(1, textRaw.length - 1).match(PARAM_EXPRESSION) || [];
+
+  if (!declaredParameters) {
+    return signature;
+  }
+
+  /**
+   * @type {string[]}
+   * @example ['sources[,', 'options]]']
+   */
+  declaredParameters = declaredParameters.split(',');
+
+  signature.params = parseParameters(declaredParameters, markdownParameters);
+
+  return signature;
+};

--- a/src/metadata.mjs
+++ b/src/metadata.mjs
@@ -138,10 +138,8 @@ const createMetadata = slugger => {
       internalMetadata.stability.toJSON = () =>
         internalMetadata.stability.children.map(node => node.data);
 
-      /**
-       * @type {ApiDocMetadataEntry}
-       */
-      const value = {
+      // Returns the Metadata entry for the API doc
+      return {
         api: apiDoc.stem,
         slug: sectionSlug,
         source_link,
@@ -156,15 +154,9 @@ const createMetadata = slugger => {
         stability: internalMetadata.stability,
         content: section,
         tags,
+        introduced_in,
         rawContent: apiDoc.toString(),
       };
-
-      if (introduced_in) {
-        value.introduced_in = introduced_in;
-      }
-
-      // Returns the Metadata entry for the API doc
-      return value;
     },
   };
 };

--- a/src/metadata.mjs
+++ b/src/metadata.mjs
@@ -155,7 +155,6 @@ const createMetadata = slugger => {
         content: section,
         tags,
         introduced_in,
-        rawContent: apiDoc.toString(),
       };
     },
   };

--- a/src/metadata.mjs
+++ b/src/metadata.mjs
@@ -113,6 +113,7 @@ const createMetadata = slugger => {
 
       const {
         type,
+        introduced_in,
         added,
         deprecated,
         removed,
@@ -137,11 +138,14 @@ const createMetadata = slugger => {
       internalMetadata.stability.toJSON = () =>
         internalMetadata.stability.children.map(node => node.data);
 
-      // Returns the Metadata entry for the API doc
-      return {
+      /**
+       * @type {ApiDocMetadataEntry}
+       */
+      const value = {
         api: apiDoc.stem,
         slug: sectionSlug,
         source_link,
+        api_doc_source: `doc/api/${apiDoc.basename}`,
         added_in: added,
         deprecated_in: deprecated,
         removed_in: removed,
@@ -152,7 +156,15 @@ const createMetadata = slugger => {
         stability: internalMetadata.stability,
         content: section,
         tags,
+        rawContent: apiDoc.toString(),
       };
+
+      if (introduced_in) {
+        value.introduced_in = introduced_in;
+      }
+
+      // Returns the Metadata entry for the API doc
+      return value;
     },
   };
 };

--- a/src/parser.mjs
+++ b/src/parser.mjs
@@ -140,8 +140,8 @@ const createParser = () => {
 
       // Visits all Text nodes from the current subtree and if there's any that matches
       // any API doc type reference and then updates the type reference to be a Markdown link
-      visit(subTree, createQueries.UNIST.isTextWithType, node =>
-        updateTypeReference(node)
+      visit(subTree, createQueries.UNIST.isTextWithType, (node, _, parent) =>
+        updateTypeReference(node, parent)
       );
 
       // Removes already parsed items from the subtree so that they aren't included in the final content

--- a/src/queries.mjs
+++ b/src/queries.mjs
@@ -81,6 +81,9 @@ const createQueries = () => {
       transformTypeToReferenceLink
     );
 
+    // This changes the type into a link by splitting it up
+    // into several nodes, and adding those nodes to the
+    // parent.
     const {
       children: [newNode],
     } = remark.parse(replacedTypes);

--- a/src/test/metadata.test.mjs
+++ b/src/test/metadata.test.mjs
@@ -73,7 +73,6 @@ describe('createMetadata', () => {
       heading,
       n_api_version: undefined,
       introduced_in: undefined,
-      rawContent: '',
       removed_in: undefined,
       slug: 'test-heading',
       source_link: 'test.com',

--- a/src/test/metadata.test.mjs
+++ b/src/test/metadata.test.mjs
@@ -66,11 +66,13 @@ describe('createMetadata', () => {
     const expected = {
       added_in: undefined,
       api: 'test',
+      api_doc_source: 'doc/api/test.md',
       changes: [],
       content: section,
       deprecated_in: undefined,
       heading,
       n_api_version: undefined,
+      rawContent: '',
       removed_in: undefined,
       slug: 'test-heading',
       source_link: 'test.com',

--- a/src/test/metadata.test.mjs
+++ b/src/test/metadata.test.mjs
@@ -72,6 +72,7 @@ describe('createMetadata', () => {
       deprecated_in: undefined,
       heading,
       n_api_version: undefined,
+      introduced_in: undefined,
       rawContent: '',
       removed_in: undefined,
       slug: 'test-heading',

--- a/src/test/queries.test.mjs
+++ b/src/test/queries.test.mjs
@@ -17,21 +17,32 @@ describe('createQueries', () => {
   // valid type
   it('should update type to reference correctly', () => {
     const queries = createQueries();
-    const node = { value: 'This is a {string} type.' };
-    queries.updateTypeReference(node);
-    strictEqual(node.type, 'html');
-    strictEqual(
-      node.value,
-      'This is a [`<string>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type) type.'
+    const node = {
+      value: 'This is a {string} type.',
+      position: { start: 0, end: 0 },
+    };
+    const parent = { children: [node] };
+    queries.updateTypeReference(node, parent);
+    deepStrictEqual(
+      parent.children.map(c => c.value),
+      [
+        'This is a ',
+        undefined, // link
+        ' type.',
+      ]
     );
   });
 
   it('should update type to reference not correctly if no match', () => {
     const queries = createQueries();
-    const node = { value: 'This is a {test} type.' };
-    queries.updateTypeReference(node);
-    strictEqual(node.type, 'html');
-    strictEqual(node.value, 'This is a {test} type.');
+    const node = {
+      value: 'This is a {test} type.',
+      position: { start: 0, end: 0 },
+    };
+    const parent = { children: [node] };
+    queries.updateTypeReference(node, parent);
+    strictEqual(parent.children[0].type, 'text');
+    strictEqual(parent.children[0].value, 'This is a {test} type.');
   });
 
   it('should add heading metadata correctly', () => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -70,6 +70,8 @@ declare global {
     slug: string;
     // The GitHub URL to the source of the API entry
     source_link: string | Array<string> | undefined;
+    // Path to the api doc file relative to the root of the nodejs repo root (ex/ `doc/api/addons.md`)
+    api_doc_source: string;
     // When a said API section got added (in which version(s) of Node.js)
     added_in: string | Array<string> | undefined;
     // When a said API section got removed (in which version(s) of Node.js)
@@ -96,6 +98,8 @@ declare global {
     // Extra YAML section entries that are stringd and serve
     // to provide additional metadata about the API doc entry
     tags: Array<string>;
+    // The raw file content
+    rawContent: string;
   }
 
   export interface ApiDocReleaseEntry {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -98,8 +98,6 @@ declare global {
     // Extra YAML section entries that are stringd and serve
     // to provide additional metadata about the API doc entry
     tags: Array<string>;
-    // The raw file content
-    rawContent: string;
   }
 
   export interface ApiDocReleaseEntry {

--- a/src/utils/parser.mjs
+++ b/src/utils/parser.mjs
@@ -123,10 +123,15 @@ export const parseHeadingIntoMetadata = (heading, depth) => {
     // Attempts to get a match from one of the heading types, if a match is found
     // we use that type as the heading type, and extract the regex expression match group
     // which should be the inner "plain" heading content (or the title of the heading for navigation)
-    const [, innerHeading] = heading.match(regex) ?? [];
+    const [, ...matches] = heading.match(regex) ?? [];
 
-    if (innerHeading && innerHeading.length) {
-      return { text: heading, type, name: innerHeading, depth };
+    if (matches?.length) {
+      return {
+        text: heading,
+        type,
+        name: matches.filter(Boolean).at(-1),
+        depth,
+      };
     }
   }
 

--- a/src/utils/parser.mjs
+++ b/src/utils/parser.mjs
@@ -129,6 +129,7 @@ export const parseHeadingIntoMetadata = (heading, depth) => {
       return {
         text: heading,
         type,
+        // The highest match group should be used.
         name: matches.filter(Boolean).at(-1),
         depth,
       };


### PR DESCRIPTION
Closes #57
Closes #141 
Closes #92

---

This is an extension of #92. This is a seperate PR due to a rebase that caused merge conflicts. 

## Description

See https://github.com/nodejs/api-docs-tooling/pull/92 for a description
## Validation

```bash
# Variables
FILENAME="$1"
NODE="path/to/node/repo"
API_DOCS_TOOLING="path/to/api-docs/tooling/repo"
DOC="$NODE/doc/api/$FILENAME.md"
OUTPUT_DIR="output"
NEW_DIR="$OUTPUT_DIR/new"
OLD_DIR="$OUTPUT_DIR/old"
SORT_JSON=$(cat <<EOF
def sorted_walk(f):
  . as \$in
  | if type == "object" then
      reduce keys[] as \$key
        ( {}; . + { (\$key):  (\$in[\$key] | sorted_walk(f)) } ) | f
  elif type == "array" then map( sorted_walk(f) ) | f
  else f
  end;

def normalize: sorted_walk(if type == "array" then sort else . end);

normalize
EOF
)

# Functions
initialize_output() {
  rm -rf "$OUTPUT_DIR" && mkdir -p "$NEW_DIR" "$OLD_DIR"
}

generate_new() {
  node "$API_DOCS_TOOLING/bin/cli.mjs" -i "$DOC" -t legacy-json -o "$NEW_DIR"
}

generate_old() {
  node "$NODE/tools/doc/generate.mjs" "$DOC" --output-directory="$OLD_DIR"
}

compare_outputs() {
  git diff --no-index <(jq --sort-keys -f <(echo $SORT_JSON) "$OLD_DIR/$FILENAME.json") <(jq --sort-keys -f <(echo $SORT_JSON) "$NEW_DIR/$FILENAME.json")
}

# Main logic
initialize_output
generate_new
generate_old
compare_outputs
```

Validate with `bash ./file.sh addons`, `bash ./file.sh fs`, etc.

### Differences

These are the small differences, and likely do not need to be fixed.

1. Highlighting is done by Shiki instead of Highlight.js
2. The old parser had issues parsing optional parameters in some cases (IIUC)
3. The old parser mistook return-ed Objects for additional parameters
4. The old parser pre-parsed the source_code YAML comments, ours does not.
5. The old parser would use the filename as the displayName for the root node, this one uses the actual display name. (E.X. fs (old) vs File System (new))
6. Links are not preserved in `textRaw` (I.E. ``[`something`][]`` in the old parser is `` `something` `` in the new one)
7. `meta` is *always* a property.

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I've covered new added functionality with unit tests if necessary.
