### PR TITLE
feat: --ignore flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ CLI tool to generate API documentation of a Node.js project.
 
 Options:
   -i, --input [patterns...]  Specify input file patterns using glob syntax
+  --ignore [patterns...]     Specify files to be ignored from the input using glob syntax
   -o, --output <path>        Specify the relative or absolute output directory
   -v, --version <semver>     Specify the target version of Node.js, semver compliant (default: "v22.6.0")
   -c, --changelog <url>      Specify the path (file: or https://) to the CHANGELOG.md file (default: "https://raw.githubusercontent.com/nodejs/node/HEAD/CHANGELOG.md")

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -31,6 +31,12 @@ program
   )
   .addOption(
     new Option(
+      '--ignore [patterns...]',
+      'Specify which input files to ignore using glob syntax'
+    )
+  )
+  .addOption(
+    new Option(
       '-o, --output <path>',
       'Specify the relative or absolute output directory'
     )
@@ -87,6 +93,7 @@ program
  */
 const {
   input,
+  ignore,
   output,
   target = [],
   version,
@@ -101,7 +108,7 @@ const linter = createLinter(lintDryRun, disableRule);
 const { loadFiles } = createMarkdownLoader();
 const { parseApiDocs } = createMarkdownParser();
 
-const apiDocFiles = loadFiles(input);
+const apiDocFiles = loadFiles(input, ignore);
 
 const parsedApiDocs = await parseApiDocs(apiDocFiles);
 

--- a/src/loaders/markdown.mjs
+++ b/src/loaders/markdown.mjs
@@ -16,14 +16,20 @@ const createLoader = () => {
    * Loads API Doc files and transforms it into VFiles
    *
    * @param {string} searchPath A glob/path for API docs to be loaded
+   * @param {string | undefined} ignorePath A glob/path of files to ignore
    * The input string can be a simple path (relative or absolute)
    * The input string can also be any allowed glob string
    *
    * @see https://code.visualstudio.com/docs/editor/glob-patterns
    */
-  const loadFiles = searchPath => {
+  const loadFiles = (searchPath, ignorePath) => {
+    const ignoredFiles = ignorePath
+      ? globSync(ignorePath).filter(filePath => extname(filePath) === '.md')
+      : [];
+
     const resolvedFiles = globSync(searchPath).filter(
-      filePath => extname(filePath) === '.md'
+      filePath =>
+        extname(filePath) === '.md' && !ignoredFiles.includes(filePath)
     );
 
     return resolvedFiles.map(async filePath => {


### PR DESCRIPTION
Allows for files to be ignored (aka removed) from the input so they won't be passed onto the generators. This is needed to support the `skip_apidoc_files` in Node's makefile (https://github.com/nodejs/node/blob/823c9b70c727e2efaa6dfd8e97551c31b45ff666/Makefile#L783)