### PR TITLE
fix(addon-verify): await files writing

### DIFF
--- a/src/generators/addon-verify/index.mjs
+++ b/src/generators/addon-verify/index.mjs
@@ -82,9 +82,12 @@ export default {
 
             await mkdir(join(output, folderName), { recursive: true });
 
-            files.forEach(async ({ name, content }) => {
-              await writeFile(join(output, folderName, name), content);
-            });
+            for await (const file of files) {
+              await writeFile(
+                join(output, folderName, file.name),
+                file.content
+              );
+            }
           }
 
           return files;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fix the missing `await` in the file writing promises

## Validation

The output files were empty before the fix

## Related Issues

Related to https://github.com/nodejs/node/pull/57343

CC @flakey5 

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I've covered new added functionality with unit tests if necessary.
