### PR TITLE
Remove assumption regarding local git clone

### DIFF
--- a/src/generators/api-links/index.mjs
+++ b/src/generators/api-links/index.mjs
@@ -54,7 +54,7 @@ export default {
     if (input.length > 0) {
       const repositoryDirectory = dirname(input[0].path);
 
-      const repository = getBaseGitHubUrl(repositoryDirectory);
+      const repository = 'https://github.com/nodejs/node';
 
       const tag = getCurrentGitHash(repositoryDirectory);
 

--- a/src/generators/api-links/index.mjs
+++ b/src/generators/api-links/index.mjs
@@ -2,10 +2,6 @@
 
 import { basename, dirname, join } from 'node:path';
 import { writeFile } from 'node:fs/promises';
-import {
-  getBaseGitHubUrl,
-  getCurrentGitHash,
-} from './utils/getBaseGitHubUrl.mjs';
 import { extractExports } from './utils/extractExports.mjs';
 import { findDefinitions } from './utils/findDefinitions.mjs';
 import { checkIndirectReferences } from './utils/checkIndirectReferences.mjs';
@@ -56,7 +52,7 @@ export default {
 
       const repository = 'https://github.com/nodejs/node';
 
-      const tag = getCurrentGitHash(repositoryDirectory);
+      const tag = 'HEAD';
 
       baseGithubLink = `${repository}/blob/${tag}`;
     }


### PR DESCRIPTION
IMO it's bad practice to assume the doc will be in a git directory, and to assume it would have an `origin` remote pointing to HTTPS or SSH GitHub repo. It would be much better to let the user opt-in into that behavior, and default to an hard-coded value.

<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I've covered new added functionality with unit tests if necessary.
