### PR TITLE
fix(test): work on both CRLF and LF machines

### DIFF
--- a/src/linter/tests/reporters/console.test.mjs
+++ b/src/linter/tests/reporters/console.test.mjs
@@ -13,14 +13,14 @@ describe('console', () => {
 
     assert.strictEqual(process.stdout.write.mock.callCount(), 3);
 
-    const callsArgs = process.stdout.write.mock.calls.map(
-      call => call.arguments[0]
+    const callsArgs = process.stdout.write.mock.calls.map(call =>
+      call.arguments[0].trim()
     );
 
     assert.deepStrictEqual(callsArgs, [
-      '\x1B[90mThis is a INFO issue at doc/api/test.md\x1B[39m\n',
-      '\x1B[33mThis is a WARN issue at doc/api/test.md (1:1)\x1B[39m\n',
-      '\x1B[31mThis is a ERROR issue at doc/api/test.md (1:1)\x1B[39m\n',
+      '\x1B[90mThis is a INFO issue at doc/api/test.md\x1B[39m',
+      '\x1B[33mThis is a WARN issue at doc/api/test.md (1:1)\x1B[39m',
+      '\x1B[31mThis is a ERROR issue at doc/api/test.md (1:1)\x1B[39m',
     ]);
   });
 });

--- a/src/linter/tests/reporters/github.test.mjs
+++ b/src/linter/tests/reporters/github.test.mjs
@@ -13,14 +13,14 @@ describe('github', () => {
 
     assert.strictEqual(process.stdout.write.mock.callCount(), 3);
 
-    const callsArgs = process.stdout.write.mock.calls.map(
-      call => call.arguments[0]
+    const callsArgs = process.stdout.write.mock.calls.map(call =>
+      call.arguments[0].trim()
     );
 
     assert.deepStrictEqual(callsArgs, [
-      '::notice file=doc/api/test.md::This is a INFO issue\n',
-      '::warning file=doc/api/test.md,line=1,endLine=1::This is a WARN issue\n',
-      '::error file=doc/api/test.md,line=1,endLine=1::This is a ERROR issue\n',
+      '::notice file=doc/api/test.md::This is a INFO issue',
+      '::warning file=doc/api/test.md,line=1,endLine=1::This is a WARN issue',
+      '::error file=doc/api/test.md,line=1,endLine=1::This is a ERROR issue',
     ]);
   });
 });


### PR DESCRIPTION
On many windows machines, lines end with `\r\n`, rather than just `\n`. This PR updates the tests to trim off the newlines, so that the test passes on both Windows and Posix machines.