### PR TITLE
fix: followup globSync fix

### DIFF
--- a/src/loaders/javascript.mjs
+++ b/src/loaders/javascript.mjs
@@ -2,8 +2,8 @@
 
 import { readFile } from 'node:fs/promises';
 import { extname } from 'node:path';
+import { globSync } from 'node:fs';
 
-import { globSync } from 'glob';
 import { VFile } from 'vfile';
 
 /**

--- a/src/loaders/markdown.mjs
+++ b/src/loaders/markdown.mjs
@@ -2,7 +2,8 @@
 
 import { readFile } from 'node:fs/promises';
 import { extname } from 'node:path';
-import { globSync } from 'fs';
+import { globSync } from 'node:fs';
+
 import { VFile } from 'vfile';
 
 /**


### PR DESCRIPTION
# 😅 

I missed the `javascript.mjs` file. (And while I'm following up, I should've used the `node:` prefix)