### PR TITLE
feat: display og images in social media

### DIFF
--- a/src/generators/legacy-html-all/index.mjs
+++ b/src/generators/legacy-html-all/index.mjs
@@ -85,7 +85,7 @@ export default {
     const generatedAllTemplate = apiTemplate
       .replace('__ID__', 'all')
       .replace(/__FILENAME__/g, 'all')
-      .replace('__SECTION__', 'All')
+      .replace(/__SECTION__/g, 'All')
       .replace(/__VERSION__/g, `v${version.toString()}`)
       .replace(/__TOC__/g, tableOfContents.wrapToC(aggregatedToC))
       .replace(/__GTOC__/g, parsedSideNav)

--- a/src/generators/legacy-html/index.mjs
+++ b/src/generators/legacy-html/index.mjs
@@ -88,7 +88,7 @@ export default {
       return apiTemplate
         .replace('__ID__', api)
         .replace(/__FILENAME__/g, api)
-        .replace('__SECTION__', section)
+        .replace(/__SECTION__/g, section)
         .replace(/__VERSION__/g, version)
         .replace(/__TOC__/g, tableOfContents.wrapToC(toc))
         .replace(/__GTOC__/g, nav)

--- a/src/generators/legacy-html/template.html
+++ b/src/generators/legacy-html/template.html
@@ -26,6 +26,13 @@
         document.documentElement.classList.add('dark-mode');
       }
     </script>
+    <meta property="og:title" content="__SECTION__ | Node.js __VERSION__ Documentation" />
+    <meta property="og:image" content="https://nodejs.org/en/next-data/og/announcement/__SECTION__%20|%20Node.js%20__VERSION__%20Documentation" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:creator" content="@nodejs" />
+    <meta name="twitter:title" content="__SECTION__ | Node.js __VERSION__ Documentation" />
+    <meta name="twitter:image" content="https://nodejs.org/static/images/logo-hexagon-card.png" />
+    <meta name="twitter:image:alt" content="The Node.js Hexagon Logo">
     <style>
       html.dark-mode .shiki,
       html.dark-mode .shiki span {


### PR DESCRIPTION
With this, the images will be displayed on social media. It's not very important, but it's a small detail

https://nodejs.org/en/next-data/og/announcement/All%20%7C%20Node.js%20v22.14.0%20Documentation

output: 
![image](https://github.com/user-attachments/assets/e9e95aeb-94e3-4604-86ad-3fce7f945d19)
