### PR TITLE
fix: ensure output directory exists before running generators

### DIFF
--- a/src/generators.mjs
+++ b/src/generators.mjs
@@ -3,7 +3,7 @@
 import publicGenerators from './generators/index.mjs';
 import astJs from './generators/ast-js/index.mjs';
 import oramaDb from './generators/orama-db/index.mjs';
-import { mkdirSync, statSync } from 'node:fs';
+import { mkdir, stat } from 'node:fs/promises';
 
 const availableGenerators = {
   ...publicGenerators,
@@ -53,12 +53,12 @@ const createGenerator = markdownInput => {
    */
   const runGenerators = async ({ generators, ...extra }) => {
     try {
-      if (!statSync(extra.output).isDirectory()) {
+      if (!(await stat(extra.output).isDirectory())) {
         throw new Error('Output is not a directory');
       }
     } catch (err) {
       if (err.code === 'ENOENT') {
-        mkdirSync(extra.output, { recursive: true });
+        mkdir(extra.output, { recursive: true });
       }
     }
 

--- a/src/generators.mjs
+++ b/src/generators.mjs
@@ -3,6 +3,7 @@
 import publicGenerators from './generators/index.mjs';
 import astJs from './generators/ast-js/index.mjs';
 import oramaDb from './generators/orama-db/index.mjs';
+import { mkdirSync, statSync } from 'node:fs';
 
 const availableGenerators = {
   ...publicGenerators,
@@ -51,6 +52,16 @@ const createGenerator = markdownInput => {
    * @param {import('./generators/types.d.ts').GeneratorOptions} options The options for the generator runtime
    */
   const runGenerators = async ({ generators, ...extra }) => {
+    try {
+      if (!statSync(extra.output).isDirectory()) {
+        throw new Error('Output is not a directory');
+      }
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        mkdirSync(extra.output, { recursive: true });
+      }
+    }
+
     // Note that this method is blocking, and will only execute one generator per-time
     // but it ensures all dependencies are resolved, and that multiple bottom-level generators
     // can reuse the already parsed content from the top-level/dependency generators


### PR DESCRIPTION
While testing this, I realized that there is no verification when --output is a file or does not exist.