### PR TITLE
fix: don’t force exit the program

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -136,4 +136,4 @@ if (target && output) {
 
 linter.report(reporter);
 
-exit(Number(linter.hasError()));
+process.exitCode = Number(linter.hasError());

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -72,7 +72,7 @@ program
       .choices(Object.keys(reporters))
       .default('console')
   )
-  .parse(argv);
+  .parse(process.argv);
 
 /**
  * @typedef {keyof generators} Target A list of the available generator names.

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { resolve } from 'node:path';
-import { argv } from 'node:process';
+import process from 'node:process';
 
 import { Command, Option } from 'commander';
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { resolve } from 'node:path';
-import { argv, exit } from 'node:process';
+import { argv } from 'node:process';
 
 import { Command, Option } from 'commander';
 


### PR DESCRIPTION
On some Windows machines (like my own), calling `process.exit()` will exit the program before all internal assertions can be completed, leading to a failed libuv assertion.

P.S. I may have hit peak programmer status—I committed, tested, and opened a PR for this change all from my phone 🤣