### PR TITLE
chore(lint): report error on invalid change versions, except REPLACEME

### DIFF
--- a/src/linter/rules/invalid-change-version.mjs
+++ b/src/linter/rules/invalid-change-version.mjs
@@ -5,22 +5,37 @@ import { env } from 'node:process';
 const NODE_RELEASED_VERSIONS = env.NODE_RELEASED_VERSIONS?.split(',');
 
 /**
+ * Checks if the given version is "REPLACEME" and the array length is 1.
+ *
+ * @param {string} version - The version to check.
+ * @param {number} length - Length of the version array.
+ * @returns {boolean} True if conditions match, otherwise false.
+ */
+const isValidReplaceMe = (version, length) =>
+  length === 1 && version === 'REPLACEME';
+
+/**
  * Determines if a given version is invalid.
  *
  * @param {string} version - The version to check.
- * @returns {boolean} True if the version is invalid, false otherwise.
+ * @param {unknown} _ - Unused parameter.
+ * @param {{ length: number }} context - Array containing the length property.
+ * @returns {boolean} True if the version is invalid, otherwise false.
  */
 const isInvalid = NODE_RELEASED_VERSIONS
-  ? version =>
-      version !== 'REPLACEME' &&
-      !NODE_RELEASED_VERSIONS.includes(version.replace(/^v/, ''))
-  : version => version !== 'REPLACEME' && !valid(version);
+  ? (version, _, { length }) =>
+      !(
+        isValidReplaceMe(version, length) ||
+        NODE_RELEASED_VERSIONS.includes(version.replace(/^v/, ''))
+      )
+  : (version, _, { length }) =>
+      !(isValidReplaceMe(version, length) || valid(version));
 
 /**
- * Checks if any change version is invalid.
+ * Identifies invalid change versions from metadata entries.
  *
- * @param {ApiDocMetadataEntry[]} entries - The metadata entries to check.
- * @returns {Array<import('../types').LintIssue>} List of lint issues found.
+ * @param {ApiDocMetadataEntry[]} entries - Metadata entries to check.
+ * @returns {import('../types').LintIssue[]} List of detected lint issues.
  */
 export const invalidChangeVersion = entries =>
   entries.flatMap(({ changes, api_doc_source, yaml_position }) =>

--- a/src/linter/rules/invalid-change-version.mjs
+++ b/src/linter/rules/invalid-change-version.mjs
@@ -12,7 +12,8 @@ const NODE_RELEASED_VERSIONS = env.NODE_RELEASED_VERSIONS?.split(',');
  */
 const isInvalid = NODE_RELEASED_VERSIONS
   ? version =>
-      version !== 'REPLACEME' && !NODE_RELEASED_VERSIONS.includes(version)
+      version !== 'REPLACEME' &&
+      !NODE_RELEASED_VERSIONS.includes(version.replace(/^v/, ''))
   : version => version !== 'REPLACEME' && !valid(version);
 
 /**

--- a/src/linter/tests/fixtures/entries.mjs
+++ b/src/linter/tests/fixtures/entries.mjs
@@ -39,6 +39,11 @@ export const assertEntry = {
       'pr-url': 'https://github.com/nodejs/node/pull/34001',
       description: "Exposed as `require('node:assert/strict')`.",
     },
+    {
+      version: 'REPLACEME',
+      'pr-url': 'https://github.com/nodejs/node/pull/12345',
+      description: 'This is a test entry.',
+    },
   ],
   heading: {
     type: 'heading',

--- a/src/linter/tests/fixtures/invalidChangeVersion-environment.mjs
+++ b/src/linter/tests/fixtures/invalidChangeVersion-environment.mjs
@@ -1,0 +1,15 @@
+import { invalidChangeVersion } from '../../rules/invalid-change-version.mjs';
+import { deepEqual } from 'node:assert';
+import { assertEntry } from './entries.mjs';
+
+const issues = invalidChangeVersion([
+  {
+    ...assertEntry,
+    changes: [
+      ...assertEntry.changes,
+      { version: ['SOME_OTHER_RELEASED_VERSION'] },
+    ],
+  },
+]);
+
+deepEqual(issues, []);

--- a/src/linter/tests/rules/invalid-change-version.test.mjs
+++ b/src/linter/tests/rules/invalid-change-version.test.mjs
@@ -21,10 +21,10 @@ describe('invalidChangeVersion', () => {
       {
         env: {
           NODE_RELEASED_VERSIONS: [
-            'v9.9.0',
-            'v13.9.0',
-            'v12.16.2',
-            'v15.0.0',
+            '9.9.0',
+            '13.9.0',
+            '12.16.2',
+            '15.0.0',
             'REPLACEME',
             'SOME_OTHER_RELEASED_VERSION',
           ].join(','),

--- a/src/linter/tests/rules/invalid-change-version.test.mjs
+++ b/src/linter/tests/rules/invalid-change-version.test.mjs
@@ -65,4 +65,30 @@ describe('invalidChangeVersion', () => {
       },
     ]);
   });
+
+  it('should return an issue if a change version contains a REPLACEME and a version', () => {
+    const issues = invalidChangeVersion([
+      {
+        ...assertEntry,
+        changes: [
+          ...assertEntry.changes,
+          { version: ['v24.0.0', 'REPLACEME'] },
+        ],
+      },
+    ]);
+
+    deepEqual(issues, [
+      {
+        level: 'error',
+        location: {
+          path: 'doc/api/assert.md',
+          position: {
+            start: { column: 1, line: 7, offset: 103 },
+            end: { column: 35, line: 7, offset: 137 },
+          },
+        },
+        message: 'Invalid version number: REPLACEME',
+      },
+    ]);
+  });
 });

--- a/src/linter/tests/rules/invalid-change-version.test.mjs
+++ b/src/linter/tests/rules/invalid-change-version.test.mjs
@@ -1,13 +1,43 @@
 import { describe, it } from 'node:test';
 import { invalidChangeVersion } from '../../rules/invalid-change-version.mjs';
-import { deepEqual } from 'node:assert';
+import { deepEqual, strictEqual } from 'node:assert';
 import { assertEntry } from '../fixtures/entries.mjs';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { execPath } from 'node:process';
 
 describe('invalidChangeVersion', () => {
-  it('should return an empty array if all change versions are valid', () => {
-    const issues = invalidChangeVersion([assertEntry]);
+  it('should work with NODE_RELEASED_VERSIONS', () => {
+    const result = spawnSync(
+      execPath,
+      [
+        fileURLToPath(
+          new URL(
+            '../fixtures/invalidChangeVersion-environment.mjs',
+            import.meta.url
+          )
+        ),
+      ],
+      {
+        env: {
+          NODE_RELEASED_VERSIONS: [
+            'v9.9.0',
+            'v13.9.0',
+            'v12.16.2',
+            'v15.0.0',
+            'REPLACEME',
+            'SOME_OTHER_RELEASED_VERSION',
+          ].join(','),
+        },
+      }
+    );
 
-    deepEqual(issues, []);
+    strictEqual(result.status, 0);
+    strictEqual(result.error, undefined);
+  });
+
+  it('should return an empty array if all change versions are valid', () => {
+    deepEqual(invalidChangeVersion([assertEntry]), []);
   });
 
   it('should return an issue if a change version is invalid', () => {
@@ -16,30 +46,22 @@ describe('invalidChangeVersion', () => {
         ...assertEntry,
         changes: [
           ...assertEntry.changes,
-          { version: ['v13.9.0', 'REPLACEME'] },
+          { version: ['v13.9.0', 'INVALID_VERSION'] },
         ],
       },
     ]);
 
     deepEqual(issues, [
       {
-        level: 'warn',
+        level: 'error',
         location: {
           path: 'doc/api/assert.md',
           position: {
-            end: {
-              column: 35,
-              line: 7,
-              offset: 137,
-            },
-            start: {
-              column: 1,
-              line: 7,
-              offset: 103,
-            },
+            start: { column: 1, line: 7, offset: 103 },
+            end: { column: 35, line: 7, offset: 137 },
           },
         },
-        message: 'Invalid version number: REPLACEME',
+        message: 'Invalid version number: INVALID_VERSION',
       },
     ]);
   });


### PR DESCRIPTION
Per https://github.com/nodejs/node/pull/57343#pullrequestreview-2711832418
> * We should not report REPLACEME as an invalid version.
> * We should report invalid versions as a hard failure.