### PR TITLE
feat(perf): offload generators to worker threads

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -77,6 +77,12 @@ program
       .choices(Object.keys(reporters))
       .default('console')
   )
+  .addOption(
+    new Option(
+      '--disable-parallelism',
+      'Disable the use of multiple threads'
+    ).default(false)
+  )
   .parse(process.argv);
 
 /**
@@ -108,6 +114,7 @@ const {
   lintDryRun,
   gitRef,
   reporter,
+  disableParallelism,
 } = program.opts();
 
 const linter = createLinter(lintDryRun, disableRule);
@@ -142,6 +149,8 @@ if (target) {
     // An URL containing a git ref URL pointing to the commit or ref that was used
     // to generate the API docs. This is used to link to the source code of the
     gitRef,
+    // Disable the use of parallel threads
+    disableParallelism,
   });
 }
 

--- a/src/generators.mjs
+++ b/src/generators.mjs
@@ -1,7 +1,7 @@
 'use strict';
 
 import { allGenerators } from './generators/index.mjs';
-import { WorkerPool } from './threading.mjs';
+import WorkerPool from './threading/index.mjs';
 
 /**
  * @typedef {{ ast: GeneratorMetadata<ApiDocMetadataEntry, ApiDocMetadataEntry>}} AstGenerator The AST "generator" is a facade for the AST tree and it isn't really a generator
@@ -46,11 +46,7 @@ const createGenerator = markdownInput => {
     // but it ensures all dependencies are resolved, and that multiple bottom-level generators
     // can reuse the already parsed content from the top-level/dependency generators
     for (const generatorName of generators) {
-      const {
-        dependsOn,
-        generate,
-        parallizable = true,
-      } = allGenerators[generatorName];
+      const { dependsOn, generate } = allGenerators[generatorName];
 
       // If the generator dependency has not yet been resolved, we resolve
       // the dependency first before running the current generator
@@ -68,7 +64,7 @@ const createGenerator = markdownInput => {
 
       // Adds the current generator execution Promise to the cache
       cachedGenerators[generatorName] =
-        threads < 2 || !parallizable
+        threads < 2
           ? generate(dependencyOutput, extra) // Run in main thread
           : threadPool.run(generatorName, dependencyOutput, threads, extra); // Offload to worker thread
     }

--- a/src/generators.mjs
+++ b/src/generators.mjs
@@ -70,15 +70,15 @@ const createGenerator = markdownInput => {
   const threadQueue = [];
 
   /**
-   *
-   * @param name
-   * @param dependencyOutput
-   * @param extra
+   * Run the input generator within a worker thread
+   * @param {keyof AllGenerators} name
+   * @param {any} dependencyOutput
+   * @param {Partial<GeneratorOptions>} extra
    */
   const runInWorker = (name, dependencyOutput, extra) => {
     return new Promise((resolve, reject) => {
       /**
-       *
+       * Run the generator
        */
       const run = () => {
         activeThreads++;
@@ -114,7 +114,7 @@ const createGenerator = markdownInput => {
   };
 
   /**
-   *
+   * Process the worker thread queue
    */
   const processQueue = () => {
     if (threadQueue.length > 0 && activeThreads < MAX_THREADS) {

--- a/src/generators.mjs
+++ b/src/generators.mjs
@@ -54,7 +54,7 @@ const createGenerator = markdownInput => {
 
       // If the generator dependency has not yet been resolved, we resolve
       // the dependency first before running the current generator
-      if (dependsOn && !(dependsOn in cachedGenerators)) {
+      if (dependsOn && dependsOn in cachedGenerators === false) {
         await runGenerators({
           ...extra,
           threads,

--- a/src/generators/index.mjs
+++ b/src/generators/index.mjs
@@ -9,8 +9,9 @@ import legacyJsonAll from './legacy-json-all/index.mjs';
 import addonVerify from './addon-verify/index.mjs';
 import apiLinks from './api-links/index.mjs';
 import oramaDb from './orama-db/index.mjs';
+import astJs from './ast-js/index.mjs';
 
-export default {
+export const publicGenerators = {
   'json-simple': jsonSimple,
   'legacy-html': legacyHtml,
   'legacy-html-all': legacyHtmlAll,
@@ -20,4 +21,11 @@ export default {
   'addon-verify': addonVerify,
   'api-links': apiLinks,
   'orama-db': oramaDb,
+};
+
+export const allGenerators = {
+  ...publicGenerators,
+  // This one is a little special since we don't want it to run unless we need
+  // it and we also don't want it to be publicly accessible through the CLI.
+  'ast-js': astJs,
 };

--- a/src/generators/json-simple/index.mjs
+++ b/src/generators/json-simple/index.mjs
@@ -6,7 +6,6 @@ import { join } from 'node:path';
 import { remove } from 'unist-util-remove';
 
 import createQueries from '../../utils/queries/index.mjs';
-import { getRemark } from '../../utils/remark.mjs';
 
 /**
  * This generator generates a simplified JSON version of the API docs and returns it as a string
@@ -35,9 +34,6 @@ export default {
    * @param {Partial<GeneratorOptions>} options
    */
   async generate(input, options) {
-    // Gets a remark processor for stringifying the AST tree into JSON
-    const remarkProcessor = getRemark();
-
     // Iterates the input (ApiDocMetadataEntry) and performs a few changes
     const mappedInput = input.map(node => {
       // Deep clones the content nodes to avoid affecting upstream nodes
@@ -49,12 +45,6 @@ export default {
         createQueries.UNIST.isStabilityNode,
         createQueries.UNIST.isHeading,
       ]);
-
-      /**
-       * For the JSON generate we want to transform the whole content into JSON
-       * @returns {string} The stringified JSON version of the content
-       */
-      content.toJSON = () => remarkProcessor.stringify(content);
 
       return { ...node, content };
     });

--- a/src/generators/legacy-html-all/index.mjs
+++ b/src/generators/legacy-html-all/index.mjs
@@ -86,7 +86,7 @@ export default {
       .replace('__ID__', 'all')
       .replace(/__FILENAME__/g, 'all')
       .replace('__SECTION__', 'All')
-      .replace(/__VERSION__/g, `v${version.toString()}`)
+      .replace(/__VERSION__/g, `v${version.version}`)
       .replace(/__TOC__/g, tableOfContents.wrapToC(aggregatedToC))
       .replace(/__GTOC__/g, parsedSideNav)
       .replace('__CONTENT__', aggregatedContent)

--- a/src/generators/legacy-html/index.mjs
+++ b/src/generators/legacy-html/index.mjs
@@ -84,7 +84,6 @@ export default {
      */
     const replaceTemplateValues = values => {
       const { api, added, section, version, toc, nav, content } = values;
-
       return apiTemplate
         .replace('__ID__', api)
         .replace(/__FILENAME__/g, api)
@@ -139,7 +138,7 @@ export default {
         api: head.api,
         added: head.introduced_in ?? '',
         section: head.heading.data.name || apiAsHeading,
-        version: `v${version.toString()}`,
+        version: `v${version.version}`,
         toc: String(parsedToC),
         nav: String(activeSideNav),
         content: parsedContent,

--- a/src/generators/legacy-html/utils/buildDropdowns.mjs
+++ b/src/generators/legacy-html/utils/buildDropdowns.mjs
@@ -60,8 +60,9 @@ const buildNavigation = navigationContents =>
 const buildVersions = (api, added, versions) => {
   // All Node.js versions that support the current API; If there's no "introduced_at" field,
   // we simply show all versions, as we cannot pinpoint the exact version
+  const coercedMajor = major(coerceSemVer(added));
   const compatibleVersions = versions.filter(({ version }) =>
-    added ? major(version) >= major(coerceSemVer(added)) : true
+    added ? version.major >= coercedMajor : true
   );
 
   // Parses the SemVer version into something we use for URLs and to display the Node.js version

--- a/src/generators/legacy-json/utils/buildSection.mjs
+++ b/src/generators/legacy-json/utils/buildSection.mjs
@@ -58,7 +58,7 @@ export const createSectionBuilder = () => {
    * @param {import('../types.d.ts').HierarchizedEntry} entry - The entry providing stability information.
    */
   const parseStability = (section, nodes, { stability }) => {
-    const stabilityInfo = stability.children.map(node => node.data);
+    const stabilityInfo = stability.children.map(node => node.data)?.[0];
 
     if (stabilityInfo) {
       section.stability = stabilityInfo.index;

--- a/src/generators/legacy-json/utils/buildSection.mjs
+++ b/src/generators/legacy-json/utils/buildSection.mjs
@@ -58,7 +58,7 @@ export const createSectionBuilder = () => {
    * @param {import('../types.d.ts').HierarchizedEntry} entry - The entry providing stability information.
    */
   const parseStability = (section, nodes, { stability }) => {
-    const stabilityInfo = stability.toJSON()?.[0];
+    const stabilityInfo = stability.children.map(node => node.data);
 
     if (stabilityInfo) {
       section.stability = stabilityInfo.index;

--- a/src/generators/types.d.ts
+++ b/src/generators/types.d.ts
@@ -1,11 +1,11 @@
 import type { SemVer } from 'semver';
 import type { ApiDocReleaseEntry } from '../types';
-import type availableGenerators from './index.mjs';
+import type { publicGenerators } from './index.mjs';
 
 declare global {
   // All available generators as an inferable type, to allow Generator interfaces
   // to be type complete and runtime friendly within `runGenerators`
-  export type AvailableGenerators = typeof availableGenerators;
+  export type AvailableGenerators = typeof publicGenerators;
 
   // This is the runtime config passed to the API doc generators
   export interface GeneratorOptions {
@@ -36,6 +36,9 @@ declare global {
     // i.e. https://github.com/nodejs/node/tree/2cb1d07e0f6d9456438016bab7db4688ab354fd2
     // i.e. https://gitlab.com/someone/node/tree/HEAD
     gitRef: string;
+
+    // The number of threads the process is allowed to use
+    threads: number;
   }
 
   export interface GeneratorMetadata<I extends any, O extends any> {

--- a/src/linter/tests/fixtures/entries.mjs
+++ b/src/linter/tests/fixtures/entries.mjs
@@ -1,11 +1,4 @@
 /**
- * Noop function.
- *
- * @returns {any}
- */
-const noop = () => {};
-
-/**
  * @type {ApiDocMetadataEntry}
  */
 export const assertEntry = {
@@ -69,12 +62,10 @@ export const assertEntry = {
       slug: 'assert',
       type: 'property',
     },
-    toJSON: noop,
   },
   stability: {
     type: 'root',
     children: [],
-    toJSON: noop,
   },
   content: {
     type: 'root',

--- a/src/metadata.mjs
+++ b/src/metadata.mjs
@@ -140,17 +140,6 @@ const createMetadata = slugger => {
       internalMetadata.heading.data.type =
         type ?? internalMetadata.heading.data.type;
 
-      /**
-       * Defines the toJSON method for the Heading AST node to be converted as JSON
-       */
-      internalMetadata.heading.toJSON = () => internalMetadata.heading.data;
-
-      /**
-       * Maps the Stability Index AST nodes into a JSON objects from their data properties
-       */
-      internalMetadata.stability.toJSON = () =>
-        internalMetadata.stability.children.map(node => node.data);
-
       // Returns the Metadata entry for the API doc
       return {
         api: apiDoc.stem,

--- a/src/test/metadata.test.mjs
+++ b/src/test/metadata.test.mjs
@@ -33,7 +33,6 @@ describe('createMetadata', () => {
     };
     metadata.addStability(stability);
     const actual = metadata.create(new VFile(), {}).stability;
-    delete actual.toJSON;
     deepStrictEqual(actual, {
       children: [stability],
       type: 'root',
@@ -82,8 +81,15 @@ describe('createMetadata', () => {
       yaml_position: {},
     };
     const actual = metadata.create(apiDoc, section);
-    delete actual.stability.toJSON;
-    delete actual.heading.toJSON;
     deepStrictEqual(actual, expected);
+  });
+
+  it('should be serializable', () => {
+    const { create } = createMetadata(new GitHubSlugger());
+    const actual = create(new VFile({ path: 'test.md' }), {
+      type: 'root',
+      children: [],
+    });
+    deepStrictEqual(structuredClone(actual), actual);
   });
 });

--- a/src/threading.mjs
+++ b/src/threading.mjs
@@ -1,0 +1,92 @@
+import {
+  Worker,
+  isMainThread,
+  parentPort,
+  workerData,
+} from 'node:worker_threads';
+import { allGenerators } from './generators/index.mjs';
+
+// If inside a worker thread, perform the generator logic here
+if (!isMainThread) {
+  const { name, dependencyOutput, extra } = workerData;
+  const generator = allGenerators[name];
+
+  // Execute the generator and send the result or error back to the parent thread
+  generator
+    .generate(dependencyOutput, extra)
+    .then(result => parentPort.postMessage(result))
+    .catch(error => parentPort.postMessage({ error }));
+}
+
+/**
+ * WorkerPool class to manage a pool of worker threads
+ */
+export class WorkerPool {
+  /** @private {number} - Number of active threads */
+  activeThreads = 0;
+  /** @private {Array<Function>} - Queue of pending tasks */
+  queue = [];
+
+  /**
+   * Runs a generator within a worker thread.
+   * @param {string} name - The name of the generator to execute
+   * @param {any} dependencyOutput - Input data for the generator
+   * @param {number} threads - Maximum number of threads to run concurrently
+   * @param {Object} extra - Additional options for the generator
+   * @returns {Promise<any>} Resolves with the generator result, or rejects with an error
+   */
+  run(name, dependencyOutput, threads, extra) {
+    return new Promise((resolve, reject) => {
+      /**
+       * Function to run the generator in a worker thread
+       */
+      const run = () => {
+        this.activeThreads++;
+
+        // Create and start the worker thread
+        const worker = new Worker(new URL(import.meta.url), {
+          workerData: { name, dependencyOutput, extra },
+        });
+
+        // Handle worker thread messages (result or error)
+        worker.on('message', result => {
+          this.activeThreads--;
+          this.processQueue(threads);
+
+          if (result?.error) {
+            reject(result.error);
+          } else {
+            resolve(result);
+          }
+        });
+
+        // Handle worker thread errors
+        worker.on('error', err => {
+          this.activeThreads--;
+          this.processQueue(threads);
+          reject(err);
+        });
+      };
+
+      // If the active thread count exceeds the limit, add the task to the queue
+      if (this.activeThreads >= threads) {
+        this.queue.push(run);
+      } else {
+        run();
+      }
+    });
+  }
+
+  /**
+   * Process the worker thread queue to start the next available task
+   * when there is room for more threads.
+   * @param {number} threads - Maximum number of threads to run concurrently
+   * @private
+   */
+  processQueue(threads) {
+    if (this.queue.length > 0 && this.activeThreads < threads) {
+      const next = this.queue.shift();
+      if (next) next();
+    }
+  }
+}

--- a/src/threading/worker.mjs
+++ b/src/threading/worker.mjs
@@ -1,0 +1,11 @@
+import { parentPort, workerData } from 'node:worker_threads';
+import { allGenerators } from '../generators/index.mjs';
+
+const { name, dependencyOutput, extra } = workerData;
+const generator = allGenerators[name];
+
+// Execute the generator and send the result or error back to the parent thread
+generator
+  .generate(dependencyOutput, extra)
+  .then(result => parentPort.postMessage(result))
+  .catch(error => parentPort.postMessage({ error }));

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -3,12 +3,6 @@ import type { Program } from 'acorn';
 import type { SemVer } from 'semver';
 import type { Data, Node, Parent, Position } from 'unist';
 
-// String serialization of the AST tree
-// @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#tojson_behavior
-interface WithJSON<T extends Node, J extends any = any> extends T {
-  toJSON: () => J;
-}
-
 // Unist Node with typed Data, which allows better type inference
 interface NodeWithData<T extends Node, J extends Data> extends T {
   data: J;
@@ -88,12 +82,9 @@ declare global {
     // Any changes to the API doc Metadata
     changes: Array<ApiDocMetadataChange>;
     // The parsed Markdown content of a Navigation Entry
-    heading: WithJSON<HeadingMetadataParent, HeadingMetadataEntry>;
+    heading: HeadingMetadataParent;
     // The API doc metadata Entry Stability Index if exists
-    stability: WithJSON<
-      StabilityIndexParent,
-      Array<StabilityIndexMetadataEntry>
-    >;
+    stability: StabilityIndexParent;
     // The subtree containing all Nodes of the API doc entry
     content: Root;
     // Extra YAML section entries that are stringd and serve


### PR DESCRIPTION
## Description

This PR offloads generators to worker threads. I've done a check of each generator, and nothing crashes, however, please please do a run through to verify nothing changed.

Because some functions cannot be cloned, `toString()` (on SemVer) has been replaced with `.version`, and similar for other SemVer related activities.

## Validation

The output should be identical to the current generation.

## Related Issues

See https://openjs-foundation.slack.com/archives/CVAMEJ4UV/p1744161814523689

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I've covered new added functionality with unit tests if necessary.
