### PR TITLE
fix(changelog): allow for non-https protocols

### DIFF
--- a/src/releases.mjs
+++ b/src/releases.mjs
@@ -38,9 +38,9 @@ const createNodeReleases = changelogPath => {
   const changelogUrl = new URL(changelogPath);
 
   const changelogStrategy =
-    changelogUrl.protocol === 'https:'
-      ? getChangelogFromNetwork(changelogUrl)
-      : getChangelogFromFileSystem(changelogUrl);
+    changelogUrl.protocol === 'file:'
+      ? getChangelogFromFileSystem(changelogUrl)
+      : getChangelogFromNetwork(changelogUrl);
 
   /**
    * Retrieves all Node.js major versions from the provided CHANGELOG.md file


### PR DESCRIPTION
## Description

We should only get the file from the file system when we're certain the URL is referencing a file. This prevents misinterpreting other protocols—like `http` instead of `https`—as file paths.

## Validation

See description

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I've covered new added functionality with unit tests if necessary.
