### PR TITLE
feat(generator): add `node.config.json`

### DIFF
--- a/src/generators/index.mjs
+++ b/src/generators/index.mjs
@@ -10,6 +10,7 @@ import addonVerify from './addon-verify/index.mjs';
 import apiLinks from './api-links/index.mjs';
 import oramaDb from './orama-db/index.mjs';
 import astJs from './ast-js/index.mjs';
+import nodeConfigSchema from './node-config-schema/index.mjs';
 
 export const publicGenerators = {
   'json-simple': jsonSimple,
@@ -21,6 +22,7 @@ export const publicGenerators = {
   'addon-verify': addonVerify,
   'api-links': apiLinks,
   'orama-db': oramaDb,
+  'node-config-schema': nodeConfigSchema,
 };
 
 export const allGenerators = {

--- a/src/generators/node-config-schema/constants.mjs
+++ b/src/generators/node-config-schema/constants.mjs
@@ -3,9 +3,8 @@ export const ERRORS = {
   missingCCandHFiles:
     'Both node_options.cc and node_options.h must be provided.',
   headerTypeNotFound:
-    'Header type for "{{headerKey}}" not found in the header file.',
-  missingTypeDefinition:
-    'No type definition found for header type "{{headerType}}" in TYPE_DEFINITION_MAP.',
+    'A type for "{{headerKey}}" not found in the header file.',
+  missingTypeDefinition: 'No type schema found for "{{type}}".',
 };
 
 // Regex pattern to match calls to the AddOption function.
@@ -14,38 +13,3 @@ export const ADD_OPTION_REGEX =
 
 // Regex pattern to match header keys in the Options class.
 export const OPTION_HEADER_KEY_REGEX = /Options::(\w+)/;
-
-// Basic JSON schema for node.config.json
-export const BASIC_SCHEMA = {
-  $schema: 'https://json-schema.org/draft/2020-12/schema',
-  additionalProperties: false,
-  properties: {
-    $schema: {
-      type: 'string',
-    },
-    nodeOptions: {
-      additionalProperties: false,
-      properties: {},
-      type: 'object',
-    },
-  },
-  type: 'object',
-};
-
-// Schema Definition Map for Data Types
-export const TYPE_DEFINITION_MAP = {
-  'std::vector<std::string>': {
-    oneOf: [
-      { type: 'string' }, // Single string case
-      {
-        items: { type: 'string', minItems: 1 }, // Array of strings, ensuring at least one item
-        type: 'array',
-      },
-    ],
-  },
-  uint64_t: { type: 'number' }, // 64-bit unsigned integer maps to a number
-  int64_t: { type: 'number' }, // 64-bit signed integer maps to a number
-  HostPort: { type: 'number' }, // HostPort is a number, like 4000
-  'std::string': { type: 'string' }, // String type
-  bool: { type: 'boolean' }, // Boolean type
-};

--- a/src/generators/node-config-schema/constants.mjs
+++ b/src/generators/node-config-schema/constants.mjs
@@ -1,0 +1,51 @@
+// Error Messages
+export const ERRORS = {
+  missingCCandHFiles:
+    'Both node_options.cc and node_options.h must be provided.',
+  headerTypeNotFound:
+    'Header type for "{{headerKey}}" not found in the header file.',
+  missingTypeDefinition:
+    'No type definition found for header type "{{headerType}}" in TYPE_DEFINITION_MAP.',
+};
+
+// Regex pattern to match calls to the AddOption function.
+export const ADD_OPTION_REGEX =
+  /AddOption[\s\n\r]*\([\s\n\r]*"([^"]+)"(.*?)\);/gs;
+
+// Regex pattern to match header keys in the Options class.
+export const OPTION_HEADER_KEY_REGEX = /Options::(\w+)/;
+
+// Basic JSON schema for node.config.json
+export const BASIC_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  additionalProperties: false,
+  properties: {
+    $schema: {
+      type: 'string',
+    },
+    nodeOptions: {
+      additionalProperties: false,
+      properties: {},
+      type: 'object',
+    },
+  },
+  type: 'object',
+};
+
+// Schema Definition Map for Data Types
+export const TYPE_DEFINITION_MAP = {
+  'std::vector<std::string>': {
+    oneOf: [
+      { type: 'string' }, // Single string case
+      {
+        items: { type: 'string', minItems: 1 }, // Array of strings, ensuring at least one item
+        type: 'array',
+      },
+    ],
+  },
+  uint64_t: { type: 'number' }, // 64-bit unsigned integer maps to a number
+  int64_t: { type: 'number' }, // 64-bit signed integer maps to a number
+  HostPort: { type: 'number' }, // HostPort is a number, like 4000
+  'std::string': { type: 'string' }, // String type
+  bool: { type: 'boolean' }, // Boolean type
+};

--- a/src/generators/node-config-schema/index.mjs
+++ b/src/generators/node-config-schema/index.mjs
@@ -5,7 +5,7 @@ import {
   OPTION_HEADER_KEY_REGEX,
 } from './constants.mjs';
 import { join } from 'node:path';
-import schema from './schema.json' with { type: 'json ' };
+import schema from './schema.json' with { type: 'json' };
 
 /**
  * This generator generates the `node.config.json` schema.

--- a/src/generators/node-config-schema/index.mjs
+++ b/src/generators/node-config-schema/index.mjs
@@ -5,6 +5,7 @@ import {
   OPTION_HEADER_KEY_REGEX,
 } from './constants.mjs';
 import { join } from 'node:path';
+import schema from './schema.json' with { type: 'json ' };
 
 /**
  * This generator generates the `node.config.json` schema.
@@ -27,16 +28,13 @@ export default {
    * @throws {Error} If the required files node_options.cc or node_options.h are missing or invalid.
    */
   async generate(_, options) {
-    let ccFile, hFile;
-
     // Ensure input files are provided and capture the paths
-    for (const filePath of options.input) {
-      if (filePath.endsWith('node_options.cc')) {
-        ccFile = filePath;
-      } else if (filePath.endsWith('node_options.h')) {
-        hFile = filePath;
-      }
-    }
+    const ccFile = options.input.find(filePath =>
+      filePath.endsWith('node_options.cc')
+    );
+    const hFile = options.input.find(filePath =>
+      filePath.endsWith('node_options.h')
+    );
 
     // Error handling if either cc or h file is missing
     if (!ccFile || !hFile) {
@@ -46,9 +44,6 @@ export default {
     // Read the contents of the cc and h files
     const ccContent = await readFile(ccFile, 'utf-8');
     const hContent = await readFile(hFile, 'utf-8');
-    const schema = JSON.parse(
-      await readFile(new URL('./schema.json', import.meta.url))
-    );
 
     const { nodeOptions } = schema.properties;
 

--- a/src/generators/node-config-schema/index.mjs
+++ b/src/generators/node-config-schema/index.mjs
@@ -1,0 +1,118 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import {
+  ERRORS,
+  ADD_OPTION_REGEX,
+  BASIC_SCHEMA,
+  OPTION_HEADER_KEY_REGEX,
+  TYPE_DEFINITION_MAP,
+} from './constants.mjs';
+import { join } from 'node:path';
+
+/**
+ * This generator generates the `node.config.json` schema.
+ *
+ * @typedef {Array<ApiDocMetadataEntry>} Input
+ *
+ * @type {GeneratorMetadata<Input, string>}
+ */
+export default {
+  name: 'node-config-schema',
+
+  version: '1.0.0',
+
+  description: 'Generates the node.config.json schema.',
+
+  /**
+   * Generates the `node.config.json` schema.
+   * @param {unknown} _ - Unused parameter
+   * @param {Partial<GeneratorOptions>} options - Options containing the input file paths
+   * @throws {Error} If the required files node_options.cc or node_options.h are missing or invalid.
+   */
+  async generate(_, options) {
+    let ccFile, hFile;
+
+    // Ensure input files are provided and capture the paths
+    for (const filePath of options.input) {
+      if (filePath.endsWith('node_options.cc')) {
+        ccFile = filePath;
+      } else if (filePath.endsWith('node_options.h')) {
+        hFile = filePath;
+      }
+    }
+
+    // Error handling if either cc or h file is missing
+    if (!ccFile || !hFile) {
+      throw new Error(ERRORS.missingCCandHFiles);
+    }
+
+    // Read the contents of the cc and h files
+    const ccContent = await readFile(ccFile, 'utf-8');
+    const hContent = await readFile(hFile, 'utf-8');
+
+    // Clone the BASIC_SCHEMA to avoid mutating the original schema object
+    /** @type {typeof BASIC_SCHEMA} */
+    const schema = Object.assign({}, BASIC_SCHEMA);
+    const { nodeOptions } = schema.properties;
+
+    // Process the cc content and match AddOption calls
+    for (const [, option, config] of ccContent.matchAll(ADD_OPTION_REGEX)) {
+      // If config doesn't include 'kAllowedInEnvvar', skip this option
+      if (!config.includes('kAllowedInEnvvar')) {
+        continue;
+      }
+
+      const headerKey = config.match(OPTION_HEADER_KEY_REGEX)?.[1];
+      // If there's no header key, it's either a V8 option or a no-op
+      if (!headerKey) {
+        continue;
+      }
+
+      // Try to find the corresponding header type in the hContent
+      const headerTypeMatch = hContent.match(
+        new RegExp(`\\s*(.+)\\s${headerKey}[^\\B_]`)
+      );
+
+      if (!headerTypeMatch) {
+        throw new Error(
+          formatErrorMessage(ERRORS.headerTypeNotFound, { headerKey })
+        );
+      }
+
+      const headerType = headerTypeMatch[1].trim();
+
+      // Ensure the headerType exists in the TYPE_DEFINITION_MAP
+      const typeDefinition = TYPE_DEFINITION_MAP[headerType];
+      if (!typeDefinition) {
+        throw new Error(
+          formatErrorMessage(ERRORS.missingTypeDefinition, { headerType })
+        );
+      }
+
+      // Add the option to the schema after removing the '--' prefix
+      nodeOptions.properties[option.replace('--', '')] = typeDefinition;
+    }
+
+    nodeOptions.properties = Object.fromEntries(
+      Object.keys(nodeOptions.properties)
+        .sort()
+        .map(key => [key, nodeOptions.properties[key]])
+    );
+
+    await writeFile(
+      join(options.output, 'node-config-schema.json'),
+      JSON.stringify(schema, null, 2) + '\n'
+    );
+
+    return schema;
+  },
+};
+
+/**
+ * Helper function to replace placeholders in error messages with dynamic values.
+ * @param {string} message - The error message with placeholders.
+ * @param {Object} params - The values to replace the placeholders.
+ * @returns {string} - The formatted error message.
+ */
+function formatErrorMessage(message, params) {
+  return message.replace(/{{(\w+)}}/g, (_, key) => params[key] || `{{${key}}}`);
+}

--- a/src/generators/node-config-schema/schema.json
+++ b/src/generators/node-config-schema/schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "nodeOptions": {
+      "additionalProperties": false,
+      "properties": {},
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/src/generators/node-config-schema/utilities.mjs
+++ b/src/generators/node-config-schema/utilities.mjs
@@ -1,0 +1,45 @@
+import { ERRORS } from './constants.mjs';
+
+/**
+ * Helper function to replace placeholders in error messages with dynamic values.
+ * @param {string} message - The error message with placeholders.
+ * @param {Object} params - The values to replace the placeholders.
+ * @returns {string} - The formatted error message.
+ */
+export function formatErrorMessage(message, params) {
+  return message.replace(/{{(\w+)}}/g, (_, key) => params[key] || `{{${key}}}`);
+}
+
+/**
+ * Returns the JSON Schema definition for a given C++ type.
+ *
+ * @param {string} type - The type to get the schema for.
+ * @returns {object} JSON Schema definition for the given type.
+ */
+export function getTypeSchema(type) {
+  switch (type) {
+    case 'std::vector<std::string>':
+      return {
+        oneOf: [
+          { type: 'string' },
+          {
+            type: 'array',
+            items: { type: 'string' },
+            minItems: 1,
+          },
+        ],
+      };
+    case 'uint64_t':
+    case 'int64_t':
+    case 'HostPort':
+      return { type: 'number' };
+    case 'std::string':
+      return { type: 'string' };
+    case 'bool':
+      return { type: 'boolean' };
+    default:
+      throw new Error(
+        formatErrorMessage(ERRORS.missingTypeDefinition, { type })
+      );
+  }
+}


### PR DESCRIPTION
## Description

This generates the https://nodejs.org/node-config-schema.json file (https://raw.githubusercontent.com/nodejs/node/main/doc/node-config-schema.json).

## Validation

Other than this schema including `experimental-quic` (which the Node core one does not), it should be a 1:1 match with the generator in Node core (This is likely due to the machine generating the node core schema not having quic).

[Example Output](https://aviv.sh/hostables/nodejs/1745190326-node-config-schema.json)

## Related Issues

Fixes #216

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I've covered new added functionality with unit tests if necessary.
