### PR TITLE
chore(lint): use `console[xyz]` over `process`

### DIFF
--- a/src/linter/reporters/console.mjs
+++ b/src/linter/reporters/console.mjs
@@ -21,10 +21,10 @@ export default issue => {
     ? ` (${issue.location.position.start.line}:${issue.location.position.end.line})`
     : '';
 
-  process.stdout.write(
+  console[issue.level](
     styleText(
       levelToColorMap[issue.level],
       `${issue.message} at ${issue.location.path}${position}`
-    ) + '\n'
+    )
   );
 };


### PR DESCRIPTION
If all of these are sent to `stdout` and the user pipes the output using `>`, the lint errors will be included. Instead, the outputs should be directed appropriately based on the context, right?