### PR TITLE
chore(readme): add badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,14 @@
   <a title="MIT License" href="LICENSE">
     <img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT License" />
   </a>
-   <a title="scorecard" href="https://securityscorecards.dev/viewer/?uri=github.com/nodejs/api-docs-tooling">
+  <a href="https://codecov.io/gh/nodejs/api-docs-tooling" >
+    <img src="https://codecov.io/gh/nodejs/api-docs-tooling/graph/badge.svg?token=TZRUKKDICU"/>
+  </a>
+  <a title="scorecard" href="https://securityscorecards.dev/viewer/?uri=github.com/nodejs/api-docs-tooling">
     <img src="https://api.securityscorecards.dev/projects/github.com/nodejs/api-docs-tooling/badge" alt="api-docs-tooling scorecard badge" />
+  </a>
+  <a href="https://www.bestpractices.dev/projects/29">
+    <img src="https://www.bestpractices.dev/projects/29/badge">
   </a>
 </p>
 


### PR DESCRIPTION
## Description

- Add codecov badge to display the code coverage on the readme
- Add "CII-Best-Practices" badge which is required by OpenSSF scorecard 

## Related Issues

No related issues, _I just noticed this_

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- **NA** I have run `node --run test` and all tests passed.
- **NA** I have check code formatting with `node --run format` & `node --run lint`.
- **NA** I've covered new added functionality with unit tests if necessary.
