### PR TITLE
fix(`HeadingMetadataEntry`): add `global`

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -21,6 +21,7 @@ declare global {
   export interface HeadingMetadataEntry {
     type:
       | 'event'
+      | 'global'
       | 'method'
       | 'property'
       | 'class'


### PR DESCRIPTION
This type is missing