### PR TITLE
feat(test): validate commands and generators

### DIFF
--- a/bin/commands/__tests__/index.test.mjs
+++ b/bin/commands/__tests__/index.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { Option } from 'commander';
+
+import commands from '../index.mjs';
+
+describe('Commands', () => {
+  it('should have unique command names', () => {
+    const names = new Set();
+
+    commands.forEach(({ name }) => {
+      assert.equal(names.has(name), false, `Duplicate command name: "${name}"`);
+      names.add(name);
+    });
+  });
+
+  it('should use correct option names', () => {
+    commands.forEach(({ name: cmdName, options }) => {
+      Object.entries(options).forEach(([optName, { flags }]) => {
+        const expectedName = new Option(flags.at(-1)).attributeName();
+        assert.equal(
+          optName,
+          expectedName,
+          `In "${cmdName}" command: option "${flags}" should be named "${expectedName}", not "${optName}"`
+        );
+      });
+    });
+  });
+});

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,9 +9,9 @@ coverage:
         target: 80%
     project:
       default:
-        # TODO(@avivkeller): Once our coverage > 50%,
-        # increase this to 50%, and increase on increments
-        target: 40%
+        # TODO(@avivkeller): Once our coverage > 70%,
+        # increase this to 70%, and increase on increments
+        target: 60%
 
 ignore:
   - 'eslint.config.mjs'

--- a/src/generators/__tests__/index.test.mjs
+++ b/src/generators/__tests__/index.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import semver from 'semver';
+
+import { allGenerators } from '../index.mjs';
+
+const validDependencies = [...Object.keys(allGenerators), 'ast'];
+const generatorEntries = Object.entries(allGenerators);
+
+describe('All Generators', () => {
+  it('should have keys matching their name property', () => {
+    generatorEntries.forEach(([key, generator]) => {
+      assert.equal(
+        key,
+        generator.name,
+        `Generator key "${key}" does not match its name property "${generator.name}"`
+      );
+    });
+  });
+
+  it('should have valid semver versions', () => {
+    generatorEntries.forEach(([key, generator]) => {
+      const isValid = semver.valid(generator.version);
+      assert.ok(
+        isValid,
+        `Generator "${key}" has invalid semver version: "${generator.version}"`
+      );
+    });
+  });
+
+  it('should have valid dependsOn references', () => {
+    generatorEntries.forEach(([key, generator]) => {
+      if (generator.dependsOn) {
+        assert.ok(
+          validDependencies.includes(generator.dependsOn),
+          `Generator "${key}" depends on "${generator.dependsOn}" which is not a valid generator or 'ast'`
+        );
+      }
+    });
+  });
+});


### PR DESCRIPTION
Follow-up #315: Prevents that from happening in the future by validating the command objects as a test.