### PR TITLE
fix(legacy-json): verify list type

### DIFF
--- a/src/generators/legacy-json/utils/__tests__/parseList.test.mjs
+++ b/src/generators/legacy-json/utils/__tests__/parseList.test.mjs
@@ -123,4 +123,50 @@ describe('parseList', () => {
     parseList(section, nodes);
     assert.ok(Array.isArray(section.params));
   });
+
+  it('processes recursive lists', () => {
+    const section = { type: 'event' };
+    const nodes = [
+      {
+        type: 'list',
+        children: [
+          {
+            children: [
+              {
+                type: 'paragraph',
+                children: [
+                  { type: 'text', value: 'param1 {string} first parameter' },
+                ],
+              },
+              // This is a nested typed list
+              {
+                type: 'list',
+                children: [
+                  {
+                    children: [
+                      {
+                        type: 'paragraph',
+                        children: [
+                          { type: 'inlineCode', value: 'option' }, // inline code
+                          { type: 'text', value: ' ' }, // space
+                          {
+                            type: 'link',
+                            children: [{ type: 'text', value: '<boolean>' }], // link with < value
+                          },
+                          { type: 'text', value: ' option description' },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    parseList(section, nodes);
+    assert.equal(section.params[0].options.length, 1);
+  });
 });

--- a/src/generators/legacy-json/utils/parseList.mjs
+++ b/src/generators/legacy-json/utils/parseList.mjs
@@ -38,6 +38,25 @@ export const extractPattern = (text, pattern, key, current) => {
 };
 
 /**
+ * Determines if the input List node is a typed list
+ * @param {import('@types/mdast').List} list
+ */
+export const isTypedList = list => {
+  const children = list?.children?.[0]?.children?.[0]?.children;
+
+  // The first element must be a code block
+  return (
+    children?.[0]?.type === 'inlineCode' &&
+    // Followed by a space
+    children?.[1]?.value.trim() === '' &&
+    // Followed by a link (type)
+    children?.[2]?.type === 'link' &&
+    // Types start with `<`
+    children?.[2]?.children?.[0]?.value?.[0] === '<'
+  );
+};
+
+/**
  * Parses an individual list item node to extract its properties
  *
  * @param {import('@types/mdast').ListItem} child
@@ -71,7 +90,7 @@ export function parseListItem(child) {
 
   // Parse nested lists (options) recursively if present
   const optionsNode = child.children.find(node => node.type === 'list');
-  if (optionsNode) {
+  if (isTypedList(optionsNode)) {
     current.options = optionsNode.children.map(parseListItem);
   }
 


### PR DESCRIPTION
Fixes #321 by verifying the list meets the following structure before parsing it as a list of options:

1. Must start with a `code`
2. Followed by a space
3. Followed by a link whose first character is `<`