### PR TITLE
chore(cov): disable patch coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,7 @@
 coverage:
   # https://docs.codecov.com/docs/commit-status
   status:
-    patch:
-      default:
-        # TODO(@avivkeller): Once our coverage > 80%,
-        # remove this, since we can easily rely on
-        # project coverage to cover patches as well
-        target: 80%
+    patch: false
     project:
       default:
         # TODO(@avivkeller): Once our coverage > 70%,


### PR DESCRIPTION
Although we haven’t reached 80% coverage yet, our patch coverage threshold has successfully served its purpose by encouraging meaningful test coverage in our PRs. Now that we’re above 70%, I’m confident we can continue to improve coverage even without enforcing the threshold.