### PR TITLE
fix(`legacy-json`): fix parameter ordering

### DIFF
--- a/src/generators/legacy-json/utils/parseSignature.mjs
+++ b/src/generators/legacy-json/utils/parseSignature.mjs
@@ -2,7 +2,7 @@
 
 import { PARAM_EXPRESSION } from '../constants.mjs';
 
-const OPTIONAL_LEVEL_CHANGES = { '[': 1, ']': -1, ' ': 0 };
+const OPTIONAL_LEVEL_CHANGES = { '[': 1, ']': -1 };
 
 /**
  * @param {Number} depth


### PR DESCRIPTION
This function was being called backwards, resulting in no parameters being marked optional.