### PR TITLE
fix(parser): transform man pages

### DIFF
--- a/src/generators/metadata/utils/parse.mjs
+++ b/src/generators/metadata/utils/parse.mjs
@@ -35,6 +35,7 @@ export const parseApiDoc = ({ file, tree }) => {
     addYAMLMetadata,
     updateMarkdownLink,
     updateTypeReference,
+    updateUnixManualReference,
     updateLinkReference,
     addStabilityMetadata,
   } = createQueries();
@@ -125,6 +126,13 @@ export const parseApiDoc = ({ file, tree }) => {
     // any API doc type reference and then updates the type reference to be a Markdown link
     visit(subTree, createQueries.UNIST.isTextWithType, (node, _, parent) =>
       updateTypeReference(node, parent)
+    );
+
+    // Visits all Unix manual references, and replaces them with links
+    visit(
+      subTree,
+      createQueries.UNIST.isTextWithUnixManual,
+      (node, _, parent) => updateUnixManualReference(node, parent)
     );
 
     // Removes already parsed items from the subtree so that they aren't included in the final content

--- a/src/utils/parser/constants.mjs
+++ b/src/utils/parser/constants.mjs
@@ -3,6 +3,9 @@
 // This is the base URL of the MDN Web documentation
 export const DOC_MDN_BASE_URL = 'https://developer.mozilla.org/en-US/docs/Web/';
 
+// The is the base URL of the Man7 documentation
+export const DOC_MAN_BASE_URL = 'http://man7.org/linux/man-pages/man';
+
 // This is the base URL for the MDN JavaScript documentation
 export const DOC_MDN_BASE_URL_JS = `${DOC_MDN_BASE_URL}JavaScript/`;
 

--- a/src/utils/parser/constants.mjs
+++ b/src/utils/parser/constants.mjs
@@ -3,7 +3,7 @@
 // This is the base URL of the MDN Web documentation
 export const DOC_MDN_BASE_URL = 'https://developer.mozilla.org/en-US/docs/Web/';
 
-// The is the base URL of the Man7 documentation
+// This is the base URL of the Man7 documentation
 export const DOC_MAN_BASE_URL = 'http://man7.org/linux/man-pages/man';
 
 // This is the base URL for the MDN JavaScript documentation

--- a/src/utils/parser/index.mjs
+++ b/src/utils/parser/index.mjs
@@ -10,6 +10,7 @@ import {
   DOC_TYPES_MAPPING_NODE_MODULES,
   DOC_TYPES_MAPPING_OTHER,
   DOC_TYPES_MAPPING_PRIMITIVES,
+  DOC_MAN_BASE_URL,
 } from './constants.mjs';
 import createQueries from '../queries/index.mjs';
 
@@ -42,6 +43,21 @@ export const normalizeYamlSyntax = yamlContent => {
     .replace('name=', 'name: ')
     .replace('llm_description=', 'llm_description: ')
     .replace(/^[\r\n]+|[\r\n]+$/g, ''); // Remove initial and final line breaks
+};
+
+/**
+ * @param {string} text The inner text
+ * @param {string} command The manual page
+ * @param {string} sectionNumber The manual section
+ * @param {string} sectionLetter The manual section number
+ */
+export const transformUnixManualToLink = (
+  text,
+  command,
+  sectionNumber,
+  sectionLetter
+) => {
+  return `[\`${text}\`](${DOC_MAN_BASE_URL}${sectionNumber}/${command}.${sectionNumber}${sectionLetter}.html)`;
 };
 
 /**

--- a/src/utils/parser/index.mjs
+++ b/src/utils/parser/index.mjs
@@ -55,7 +55,7 @@ export const transformUnixManualToLink = (
   text,
   command,
   sectionNumber,
-  sectionLetter
+  sectionLetter = ''
 ) => {
   return `[\`${text}\`](${DOC_MAN_BASE_URL}${sectionNumber}/${command}.${sectionNumber}${sectionLetter}.html)`;
 };

--- a/src/utils/queries/index.mjs
+++ b/src/utils/queries/index.mjs
@@ -208,8 +208,8 @@ createQueries.QUERIES = {
   stabilityIndexPrefix: /Stability: ([0-5])/,
   // ReGeX for retrieving the inner content from a YAML block
   yamlInnerContent: /^<!--[ ]?(?:YAML([\s\S]*?)|([ \S]*?))?[ ]?-->/,
-  // RegEX for finding references to Unix manuals
-  unixManualPage: /\b([a-z.]+)\((\d)([a-z]?)\)/gm,
+  // ReGeX for finding references to Unix manuals
+  unixManualPage: /\b([a-z.]+)\((\d)([a-z]?)\)/g,
 };
 
 createQueries.UNIST = {


### PR DESCRIPTION
Fixes #346 by adding a transformer for Unix Manual syntax. That way, when `chmod(1)` (or similar) is put the documentation, it'll link to the https://man7.org/linux/man-pages/ reference.