### PR TITLE
ci: set 3-day cooldown for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
     cooldown:
       default-days: 3
     groups:
-      fromat:
+      format:
         patterns:
           - 'prettier'
       lint:


### PR DESCRIPTION
## Description

Reduces the risk from compromised dependency versions by requiring that they've been published for at least three days before Dependabot will update us to them, giving time for maintainers and the community to spot and resolve compromises.

## Validation
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-

## Related Issues

https://github.com/nodejs/web-team/issues/25

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
