### PR TITLE
fix: set `maxRetries` to 10 when deleting assets folder

### DIFF
--- a/src/generators/legacy-html/index.mjs
+++ b/src/generators/legacy-html/index.mjs
@@ -175,7 +175,7 @@ export default {
       // Removes the current assets directory to copy the new assets
       // and prevent stale assets from existing in the output directory
       // If the path does not exists, it will simply ignore and continue
-      await rm(assetsFolder, { recursive: true, force: true });
+      await rm(assetsFolder, { recursive: true, force: true, maxRetries: 10 });
 
       // We copy all the other assets to the output folder at the end of the process
       // to ensure that all latest changes on the styles are applied to the output


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Set `maxRetries` option to 10 when deleting the assets folder copied over by the legacy html generator re https://github.com/nodejs/node/pull/57343#issuecomment-3472712267

10 is arbitrary, can be any number.

Related: https://github.com/nodejs/node/issues/54561

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
