### PR TITLE
fix: remove excess margin between types

### DIFF
--- a/src/generators/web/ui/index.css
+++ b/src/generators/web/ui/index.css
@@ -20,6 +20,9 @@ main {
   .overflow-container {
     overflow-x: auto;
     width: 100%;
+    table td a + a {
+      margin-right: 0;
+    }
   }
 
   table {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
<img width="1641" height="1150" alt="image" src="https://github.com/user-attachments/assets/6306abd6-8e56-4605-b5be-fd7463761dc6" />

Different types are already separated by ` | `, so there's no need to add extra margins through styles.
<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
