### PR TITLE
feat(vercel): copy API markdown files to output directory

### DIFF
--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -9,6 +9,6 @@ node bin/cli.mjs generate \
   --index "./node/doc/api/index.md" \
   --log-level debug
 
-cp "./node/doc/api/*.md" "./out"
+cp ./node/doc/api/*.md "./out"
 
 rm -rf node/


### PR DESCRIPTION
This'll make our Vercel output a bit more in-line with the current output.