### PR TITLE
fix: hide copy button when JS is disabled and when printing

### DIFF
--- a/src/generators/legacy-html/assets/style.css
+++ b/src/generators/legacy-html/assets/style.css
@@ -1014,9 +1014,6 @@ kbd {
   filter: invert(1);
 }
 
-:root:not(.has-js) .copy-button {
-  display: none;
-}
 .copy-button {
   float: right;
   outline: none;
@@ -1041,6 +1038,10 @@ kbd {
 
 .copy-button:hover {
   background-color: var(--green2);
+}
+
+:root:not(.has-js) .copy-button {
+  display: none;
 }
 
 @supports (aspect-ratio: 1 / 1) {
@@ -1125,7 +1126,13 @@ kbd {
     border-bottom: 1px solid var(--color-text-primary);
   }
 
-  .js-flavor-toggle ~ * {
+  .js-flavor-toggle + * {
+    margin-bottom: 2rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid var(--color-text-primary);
+  }
+
+  .js-flavor-toggle ~ :not(.copy-button) {
     display: block !important;
     background-position: top right;
     background-size: 142px 20px;
@@ -1138,6 +1145,10 @@ kbd {
 
   .js-flavor-toggle ~ .mjs {
     background-image: url('./js-flavor-esm.svg');
+  }
+
+  .copy-button {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Description

And move the button to the bottom of the box to align with previous tooling

## Validation

| JS enabled | `main` | This PR |
| - | - | - |
| Yes | ![](https://github.com/user-attachments/assets/a092249b-a516-4fd8-b68d-07447b3bfdb2) | ![](https://github.com/user-attachments/assets/bcba3287-8c24-4b0a-a4aa-e86478345733) |
| No | ![](https://github.com/user-attachments/assets/0329b446-7395-4f30-bce7-e6c39bad6430) | ![](https://github.com/user-attachments/assets/ef870645-3ccf-467b-a2d9-cef19dd04ca6) |
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->



<!-- Write a brief description of the changes introduced by this PR -->



<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
