### PR TITLE
ci: add auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,26 @@
+name: Auto-merge PRs
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    if: github.repository == 'nodejs/doc-kit'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: nodejs/web-team/actions/auto-merge-prs@b087df186d25f8792fb85cc7794f68718726b8ee
+        with:
+          merge-method: queue


### PR DESCRIPTION
## Description

Enables the same workflow we enabled in web-team, to handle automatically merging PRs (from branches within the repo, not forks) automatically after 48hrs assuming they are mergeable.

## Validation

N/A

## Related Issues

cc https://github.com/nodejs/nodejs.org/pull/8701

cc https://github.com/nodejs/web-team/pull/107 https://github.com/nodejs/web-team/pull/108 https://github.com/nodejs/web-team/pull/109

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
