### PR TITLE
fix: prevent grouping consecutive code blocks with the same language

### DIFF
--- a/src/utils/highlighter.mjs
+++ b/src/utils/highlighter.mjs
@@ -145,8 +145,8 @@ export default function rehypeShikiji() {
         // with different languages in order to create a switchable code tab
         if (
           codeElements.length === 2 &&
-          codeElements[0]?.properties?.language !==
-            codeElements[1]?.properties?.language
+          codeElements[0].properties?.language !==
+            codeElements[1].properties?.language
         ) {
           const switchablePreElement = createElement(
             'pre',


### PR DESCRIPTION
Two consecutive code blocks with the same language (e.g., both `mjs`) were incorrectly grouped into a CJS/MJS switchable tab. This adds a check to ensure the two code blocks have different languages before creating a switchable code tab.

Refs: https://github.com/nodejs/node/pull/62181