### PR TITLE
style(web): Removing Empty Space From Search Box layout 

### DIFF
--- a/src/generators/web/ui/components/SearchBox/index.module.css
+++ b/src/generators/web/ui/components/SearchBox/index.module.css
@@ -1,6 +1,5 @@
 .searchResultsContainer {
   display: flex;
-  flex-grow: 1;
   flex-direction: column;
   overflow-y: auto;
 }
@@ -8,14 +7,12 @@
 .footer {
   display: flex;
   justify-content: center;
-  align-items: baseline;
-  padding: 1rem;
-  border-top: 1px solid var(--color-neutral-200);
+  align-items: center;
+  padding: 0.75rem;
   background-color: var(--color-neutral-100);
 }
 
 :where([data-theme='dark'], [data-theme='dark'] *) .footer {
-  border-top-color: var(--color-neutral-900);
   background-color: var(--color-neutral-950);
 }
 
@@ -29,7 +26,7 @@
 .shortcutWrapper {
   display: none;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.375rem;
 }
 
 @media (min-width: 1024px) {
@@ -41,7 +38,7 @@
 .shortcutItem {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.375rem;
   font-size: 0.75rem;
   color: var(--color-neutral-800);
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR improves the visual layout of the Search Box component by:
- Removing the redundant top border from the footer to create a cleaner, single-line separation.
- Tightening the footer layout by reducing padding and gaps between shortcut keys and labels for a more premium look.
- Ensuring perfect vertical alignment of shortcut items.

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

I have validated these changes by:
1. Generating the documentation using `npm run run generate -- -i "docs/commands.md" -t web orama-db -o out`.
2. Serving the output and visually verifying the search box across different states (empty vs. with results).
3. Confirming that the double-line border issue is resolved.

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

Fix #670 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
