### PR TITLE
fix: use absolute positioning for copy button in code blocks

### DIFF
--- a/src/generators/legacy-html/assets/api.js
+++ b/src/generators/legacy-html/assets/api.js
@@ -180,7 +180,7 @@ const setupFlavorToggles = () => {
 const setupCopyButton = () => {
   document.querySelectorAll('.copy-button').forEach(button => {
     button.addEventListener('click', e => {
-      const parent = e.target.parentNode;
+      const parent = e.target.closest('pre');
       const flavorToggle = parent.querySelector('.js-flavor-toggle');
 
       let code;

--- a/src/generators/legacy-html/assets/style.css
+++ b/src/generators/legacy-html/assets/style.css
@@ -540,8 +540,7 @@ tt,
 }
 
 pre {
-  position: relative;
-  padding: 1rem;
+  padding: 1rem 1rem 0.5rem;
   vertical-align: top;
   border-radius: 4px;
   margin: 1rem;
@@ -1015,10 +1014,24 @@ kbd {
   filter: invert(1);
 }
 
+.code-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid rgb(128 128 128 / 20%);
+}
+
+.code-language {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: 700;
+  opacity: 0.6;
+}
+
 .copy-button {
-  position: absolute;
-  right: 1rem;
-  bottom: 1rem;
   outline: none;
   font-size: 10px;
   color: #fff;
@@ -1134,7 +1147,7 @@ kbd {
     border-bottom: 1px solid var(--color-text-primary);
   }
 
-  .js-flavor-toggle ~ :not(.copy-button) {
+  .js-flavor-toggle ~ :not(.code-toolbar) {
     display: block !important;
     background-position: top right;
     background-size: 142px 20px;
@@ -1149,7 +1162,7 @@ kbd {
     background-image: url('./js-flavor-esm.svg');
   }
 
-  .copy-button {
+  .code-toolbar {
     display: none;
   }
 }

--- a/src/utils/highlighter.mjs
+++ b/src/utils/highlighter.mjs
@@ -10,13 +10,18 @@ import shikiConfig from '../../shiki.config.mjs';
 // to attribute the current language of the <pre> element
 const languagePrefix = 'language-';
 
-// Creates a static button element which is used for the "copy" button
-// within codeboxes for copying the code to the clipboard
-const copyButtonElement = createElement(
-  'button',
-  { class: 'copy-button' },
-  'copy'
-);
+/**
+ * Creates a toolbar element with a language label and copy button.
+ *
+ * @param {string} languageId - The language identifier for the code block.
+ * @returns {import('hast').Element} The toolbar element.
+ */
+function createToolbarElement(languageId) {
+  return createElement('div', { class: 'code-toolbar' }, [
+    createElement('span', { class: 'code-language' }, languageId),
+    createElement('button', { class: 'copy-button' }, 'copy'),
+  ]);
+}
 
 /**
  * Checks if the given node is a valid code element.
@@ -103,8 +108,8 @@ export default function rehypeShikiji() {
       // Adds the original language back to the <pre> element
       children[0].properties.class = `${children[0].properties.class} ${codeLanguage}`;
 
-      // Adds the "copy" button to the <pre> element
-      children[0].children.push(copyButtonElement);
+      // Adds the toolbar (language label + copy button) to the <pre> element
+      children[0].children.push(createToolbarElement(languageId));
 
       // Replaces the <pre> element with the updated one
       parent.children.splice(index, 1, ...children);
@@ -165,7 +170,7 @@ export default function rehypeShikiji() {
                 checked: codeElements[0].properties.language === 'cjs',
               }),
               ...codeElements,
-              copyButtonElement,
+              createToolbarElement('javascript'),
             ]
           );
 


### PR DESCRIPTION

<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The copy button was using `float: right` which caused it to take up space in the document flow, resulting in an extra empty line appearing at the bottom of code blocks.

Switch to `position: absolute` with `right: 1rem` and `bottom: 1rem` to overlay the button without affecting the code block layout. This also adds `position: relative` to `pre` elements to establish the positioning context.


## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

| before | after |
| ----- | ----- |
| <img width="1448" height="1202" alt="スクリーンショット 2026-03-17 22 40 41" src="https://github.com/user-attachments/assets/084af87c-dfc1-4292-a531-dfc6341dff3d" /> | <img width="1448" height="1202" alt="スクリーンショット 2026-03-17 22 41 48" src="https://github.com/user-attachments/assets/667b59d1-14f4-4628-81f3-503f64f60e80" /> |

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Refs: https://github.com/nodejs/doc-kit/pull/635

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
