### PR TITLE
fix(legacy-json): prevent parseSignature from dropping arguments on u…

### DIFF
--- a/src/generators/legacy-json/utils/__tests__/parseSignature.test.mjs
+++ b/src/generators/legacy-json/utils/__tests__/parseSignature.test.mjs
@@ -273,6 +273,26 @@ describe('parseSignature', () => {
         ],
       },
     },
+    {
+      name: 'handles un-backticked method signatures without dropping arguments',
+      input: {
+        textRaw: 'new Console(options)',
+        markdown: [{ name: 'options' }],
+      },
+      expected: {
+        params: [{ name: 'options' }],
+      },
+    },
+    {
+      name: 'handles standard method signatures without backticks',
+      input: {
+        textRaw: 'foo(a, b)',
+        markdown: [{ name: 'a' }, { name: 'b' }],
+      },
+      expected: {
+        params: [{ name: 'a' }, { name: 'b' }],
+      },
+    },
   ];
 
   for (const testCase of testCases) {

--- a/src/generators/legacy-json/utils/parseSignature.mjs
+++ b/src/generators/legacy-json/utils/parseSignature.mjs
@@ -190,7 +190,7 @@ export default (textRaw, markdownParameters) => {
    * @example `[sources[, options]]`
    */
   let [, declaredParameters] =
-    textRaw.substring(1, textRaw.length - 1).match(PARAM_EXPRESSION) || [];
+    textRaw.replace(/^`|`$/g, '').match(PARAM_EXPRESSION) || [];
 
   if (!declaredParameters) {
     return signature;


### PR DESCRIPTION
## Description
When the legacy-json generator parses method signatures, it was dropping parameters if the signature was not wrapped in markdown backticks (like `new Console(options)` instead of `` `new Console(options)` ``).

This happens because the parser was blindly using `substring(1, length - 1)` before running its regex, assuming the first and last characters were always backticks or parentheses. This corrupted un-wrapped strings and caused the parameters to be dropped entirely in the generated JSON.

I removed the dangerous substring call and replaced it with a safe backtick replacement regex. This ensures arguments for un-backticked methods and constructors are properly extracted.

## Validation
Run `node --run test` to verify. All tests pass, and I added regression test cases in `parseSignature.test.mjs` to ensure un-backticked signatures are parsed correctly without dropping arguments.

## Related Issues
No related issue, internal codebase discovery.

## Check List
- [x] I have read the Contributing Guidelines and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
