### PR TITLE
fix: disable wasm highlighter on riscv64

### DIFF
--- a/src/utils/configuration/index.mjs
+++ b/src/utils/configuration/index.mjs
@@ -5,6 +5,7 @@ import { coerce } from 'semver';
 
 import { CHANGELOG_URL, populate } from './templates.mjs';
 import { allGenerators } from '../../generators/index.mjs';
+import logger from '../../logger/index.mjs';
 import { parseChangelog, parseIndex } from '../../parsers/markdown.mjs';
 import { enforceArray } from '../array.mjs';
 import { leftHandAssign } from '../generators.mjs';
@@ -33,7 +34,11 @@ export const getDefaultConfig = lazy(() =>
         }),
       },
 
-      threads: cpus().length,
+      // The number of wasm memory instances is severely limited on
+      // riscv64 with sv39. Running multiple generators that use wasm in
+      // parallel could cause failures to allocate new wasm instance.
+      // See also https://github.com/nodejs/node/pull/60591
+      threads: process.arch === 'riscv64' ? 1 : cpus().length,
       chunkSize: 10,
     })
   )
@@ -120,6 +125,14 @@ export const createRunConfiguration = async options => {
   // These need to be coerced
   merged.threads = Math.max(merged.threads, 1);
   merged.chunkSize = Math.max(merged.chunkSize, 1);
+
+  if (process.arch === 'riscv64' && merged.threads > 1) {
+    logger.warn(
+      `Using ${merged.threads} threads might cause failures when` +
+        'allocating wasm memory due to insufficient virtual address space' +
+        'on riscv64 with sv39. Please consider using only a single thread.'
+    );
+  }
 
   // Transform global config if it wasn't already done
   await transformConfig(merged.global);

--- a/src/utils/highlighter.mjs
+++ b/src/utils/highlighter.mjs
@@ -37,13 +37,10 @@ function isCodeBlock(node) {
 }
 
 export const highlighter = await createHighlighter({
-  // s390x machines throw memory issues on WASM builds
-  // https://github.com/nodejs/node/blob/c9acf345922bd758fbb3f16ee6256aa165260219/test/common/sea.js#L55
-  //
   // riscv64 with sv39 has limited virtual memory space, where creating
   // too many (>20) wasm memory instances fails.
   // https://github.com/nodejs/node/pull/60591
-  wasm: !['riscv64', 's390x'].includes(process.arch),
+  wasm: process.arch !== 'riscv64',
 });
 
 /**

--- a/src/utils/highlighter.mjs
+++ b/src/utils/highlighter.mjs
@@ -39,7 +39,11 @@ function isCodeBlock(node) {
 export const highlighter = await createHighlighter({
   // s390x machines throw memory issues on WASM builds
   // https://github.com/nodejs/node/blob/c9acf345922bd758fbb3f16ee6256aa165260219/test/common/sea.js#L55
-  wasm: process.arch !== 's390x',
+  //
+  // riscv64 with sv39 has limited virtual memory space, where creating
+  // too many (>20) wasm memory instances fails.
+  // https://github.com/nodejs/node/pull/60591
+  wasm: !['riscv64', 's390x'].includes(process.arch),
 });
 
 /**


### PR DESCRIPTION


<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

riscv64 with sv39 has limited virtual memory space, where creating too many (>=20) wasm memory instances fails.
See https://github.com/nodejs/node/pull/60591 for more details.

This PR fixes the following error encountered during `make test-only` on riscv64:

    [07:02:55.797] ERROR: WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance
    RangeError: WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instancemake[1]: *** [Makefile:392: test/addons/.docbuildstamp] Error 1
    make: *** [Makefile:352: test-only] Error 2

I also limited the number of threads to 1 for riscv64 for the same reason, as `@minify-html/wasm` is used in several generators.

While at it, re-enable wasm highlighter for s390x because the corresponding bug has been fixed.
<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

Patch `tools/doc/node_modules/@nodejs/doc-kit/src/utils/highlighter.mjs ` and run `make test-only` again on riscv64 linux.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
