### PR TITLE
fix(ci): auto-merge does not need to queue PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -22,4 +22,4 @@ jobs:
 
       - uses: nodejs/web-team/actions/auto-merge-prs@b087df186d25f8792fb85cc7794f68718726b8ee
         with:
-          merge-method: queue
+          merge-method: squash


### PR DESCRIPTION
## Description

https://github.com/nodejs/doc-kit/actions/runs/22915731961/job/66500453419#step:4:156

## Validation

Workflow updated.

## Related Issues

N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
