### PR TITLE
ci: add auto-merge label to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
+    labels:
+      - dependencies
+      - github_actions
+      - auto-merge
     commit-message:
       prefix: meta
     cooldown:
@@ -19,6 +23,10 @@ updates:
     versioning-strategy: increase
     schedule:
       interval: monthly
+    labels:
+      - dependencies
+      - javascript
+      - auto-merge
     commit-message:
       prefix: meta
     cooldown:


### PR DESCRIPTION
## Description

Automatically adds the `auto-merge` label to all Dependabot-created PRs, so that we only need to approve them in an initial review, and automation will handle landing them with no further interaction needed from maintainers.

## Validation

Config valid.

## Related Issues

N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
