### PR TITLE
docs(README): replace “doc-kit” with “@node-core/doc-kit” in the npx command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 Local invocation:
 
 ```sh
-$ npx doc-kit --help
+$ npx @node-core/doc-kit --help
 ```
 
 ```sh
@@ -90,7 +90,7 @@ Options:
 To generate a 1:1 match with the [legacy tooling](https://github.com/nodejs/node/tree/main/tools/doc), use the `legacy-html`, `legacy-json`, `legacy-html-all`, and `legacy-json-all` generators.
 
 ```sh
-npx doc-kit generate \
+npx @node-core/doc-kit generate \
   -t legacy-html \
   -t legacy-json \
   -i "path/to/node/doc/api/*.md" \
@@ -103,7 +103,7 @@ npx doc-kit generate \
 To generate [our redesigned documentation pages](https://nodejs-api-docs-tooling.vercel.app), use the `web` and `orama-db` (for search) generators.
 
 ```sh
-npx doc-kit generate \
+npx @node-core/doc-kit generate \
   -t web \
   -t orama-db \
   -i "path/to/node/doc/api/*.md" \


### PR DESCRIPTION
## Description

Just fix the command because running `npx doc-kit` returns the following error: 
> The requested resource ‘doc-kit@*’ could not be found or you do not have permission to access it.

That's because the package is from the “@node-core” organization, so you install it like this: `npx @node-core/doc-kit`


## Validation

Just run the command.

## Related Issues

None.

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
