### PR TITLE
feat: restore legacy anchor alias to preserve old links

### DIFF
--- a/src/generators/legacy-html/utils/__tests__/slugger.test.mjs
+++ b/src/generators/legacy-html/utils/__tests__/slugger.test.mjs
@@ -7,39 +7,33 @@ import { createLegacySlugger } from '../slugger.mjs';
 
 describe('createLegacySlugger', () => {
   it('prefixes with api stem and uses underscores', () => {
-    const slugger = createLegacySlugger();
-    assert.strictEqual(
-      slugger.getLegacySlug('File System', 'fs'),
-      'fs_file_system'
-    );
+    const getLegacySlug = createLegacySlugger();
+    assert.strictEqual(getLegacySlug('File System', 'fs'), 'fs_file_system');
   });
 
   it('replaces special characters with underscores', () => {
-    const slugger = createLegacySlugger();
+    const getLegacySlug = createLegacySlugger();
     assert.strictEqual(
-      slugger.getLegacySlug('fs.readFile(path)', 'fs'),
+      getLegacySlug('fs.readFile(path)', 'fs'),
       'fs_fs_readfile_path'
     );
   });
 
   it('strips leading and trailing underscores', () => {
-    const slugger = createLegacySlugger();
-    assert.strictEqual(slugger.getLegacySlug('Hello', 'fs'), 'fs_hello');
+    const getLegacySlug = createLegacySlugger();
+    assert.strictEqual(getLegacySlug('Hello', 'fs'), 'fs_hello');
   });
 
   it('prefixes with underscore when result starts with non-alpha', () => {
-    const slugger = createLegacySlugger();
-    assert.strictEqual(
-      slugger.getLegacySlug('123 test', '0num'),
-      '_0num_123_test'
-    );
+    const getLegacySlug = createLegacySlugger();
+    assert.strictEqual(getLegacySlug('123 test', '0num'), '_0num_123_test');
   });
 
   it('deduplicates with a counter for identical titles', () => {
-    const slugger = createLegacySlugger();
-    assert.strictEqual(slugger.getLegacySlug('Hello', 'fs'), 'fs_hello');
-    assert.strictEqual(slugger.getLegacySlug('Hello', 'fs'), 'fs_hello_1');
-    assert.strictEqual(slugger.getLegacySlug('Hello', 'fs'), 'fs_hello_2');
-    assert.strictEqual(slugger.getLegacySlug('World', 'fs'), 'fs_world');
+    const getLegacySlug = createLegacySlugger();
+    assert.strictEqual(getLegacySlug('Hello', 'fs'), 'fs_hello');
+    assert.strictEqual(getLegacySlug('Hello', 'fs'), 'fs_hello_1');
+    assert.strictEqual(getLegacySlug('Hello', 'fs'), 'fs_hello_2');
+    assert.strictEqual(getLegacySlug('World', 'fs'), 'fs_world');
   });
 });

--- a/src/generators/legacy-html/utils/buildContent.mjs
+++ b/src/generators/legacy-html/utils/buildContent.mjs
@@ -223,7 +223,7 @@ const buildMetadataElement = (node, remark) => {
  * @param {import('unified').Processor} remark The Remark instance to be used to process
  */
 export default (headNodes, metadataEntries, remark) => {
-  const legacySlugger = createLegacySlugger();
+  const getLegacySlug = createLegacySlugger();
 
   // Creates the root node for the content
   const parsedNodes = createTree(
@@ -234,13 +234,14 @@ export default (headNodes, metadataEntries, remark) => {
       const content = structuredClone(entry.content);
 
       // Parses the Heading nodes into Heading elements
-      visit(content, UNIST.isHeading, (node, index, parent) => {
-        const legacySlug = legacySlugger.getLegacySlug(
-          node.data.text,
-          entry.api
-        );
-        buildHeading(node, index, parent, legacySlug);
-      });
+      visit(content, UNIST.isHeading, (node, index, parent) =>
+        buildHeading(
+          node,
+          index,
+          parent,
+          getLegacySlug(node.data.text, entry.api)
+        )
+      );
 
       // Parses the Blockquotes into Stability elements
       // This is treated differently as we want to preserve the position of a Stability Index

--- a/src/generators/legacy-html/utils/slugger.mjs
+++ b/src/generators/legacy-html/utils/slugger.mjs
@@ -1,48 +1,23 @@
 'use strict';
 
-const notAlphaNumerics = /[^a-z0-9]+/g;
-const edgeUnderscores = /^_+|_+$/g;
-const notAlphaStart = /^[^a-z]/;
-
 /**
- * Deduplicates legacy slugs by appending an incremented counter.
- * Adapted from maintainer suggestion to preserve `id` on first occurrence.
+ * Creates a stateful slugger for legacy anchor links.
  *
- * @param {Record<string, number>} counters
- * @returns {(id: string) => string}
+ * Generates underscore-separated slugs in the form `{apiStem}_{text}`,
+ * appending `_{n}` for duplicates to preserve historical anchor compatibility.
+ *
+ * @returns {(text: string, apiStem: string) => string}
  */
-export const legacyDeduplicator =
-  (counters = { __proto__: null }) =>
-  id => {
+export const createLegacySlugger =
+  (counters = {}) =>
+  (text, apiStem) => {
+    const id = `${apiStem}_${text}`
+      .toLowerCase()
+      .replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '')
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^\d/, '_$&');
+
     counters[id] ??= -1;
     const count = ++counters[id];
     return count > 0 ? `${id}_${count}` : id;
   };
-
-/**
- * Creates a stateful slugger for legacy anchor links.
- *
- * @returns {{ getLegacySlug: (text: string, apiStem: string) => string }}
- */
-export const createLegacySlugger = () => {
-  const deduplicate = legacyDeduplicator();
-
-  return {
-    /**
-     * Generates a legacy-style slug to preserve old anchor links.
-     *
-     * @param {string} text The heading text
-     * @param {string} apiStem The API file identifier (e.g. 'fs', 'http')
-     * @returns {string} The legacy slug
-     */
-    getLegacySlug: (text, apiStem) => {
-      const id = `${apiStem}_${text}`
-        .toLowerCase()
-        .replace(notAlphaNumerics, '_')
-        .replace(edgeUnderscores, '')
-        .replace(notAlphaStart, '_$&');
-
-      return deduplicate(id);
-    },
-  };
-};


### PR DESCRIPTION
Fixes: https://github.com/nodejs/doc-kit/issues/697

## Description

Restores the legacy anchor alias for headings to preserve old documentation links.

The old Node.js doc generator (`tools/doc/html.mjs`) produced two anchor IDs per heading — a modern GitHub-style slug (e.g., `#file-system`) and a legacy underscore-based slug prefixed with the filename (e.g., `#fs_file_system`). External sites like Express and many others still link to these legacy anchors, and since doc-kit dropped them, those links silently break.

This PR ports the old `getLegacyId` algorithm into doc-kit and renders a hidden `<a>` element with the legacy ID alongside every heading, so both old and new anchor links resolve correctly.

### Changes

- **`src/generators/metadata/utils/slugger.mjs`** — Added `getLegacySlug()` function implementing the old underscore-based slug algorithm, and added a `legacySlug()` method to `createNodeSlugger` with counter-based deduplication.
- **`src/generators/metadata/types.d.ts`** — Added `legacySlug: string` field to `HeadingData` interface.
- **`src/generators/metadata/utils/parse.mjs`** — Generate `legacySlug` for every heading during metadata parsing.
- **`src/generators/legacy-html/utils/buildContent.mjs`** — Render a hidden legacy anchor `<a>` element in the legacy HTML output.
- **`src/generators/jsx-ast/utils/buildContent.mjs`** — Render a hidden legacy anchor `<a>` element in the JSX/AST (web) output.
- **`src/generators/metadata/utils/__tests__/slugger.test.mjs`** — Added tests for `getLegacySlug` and `createNodeSlugger.legacySlug`.

## Validation

- All 349 existing tests pass (`npm test`).
- Lint and formatting checks pass (`npm run lint`, `npm run format:check`).
- Locally generated HTML output for a sample `fs.md` file confirms both anchors are present:
  - `<a id=fs_file_system></a>` (legacy) alongside `<a class=mark id=file-system>` (modern)
  - `<a id=fs_fs_readfile_path></a>` (legacy) alongside `<a class=mark id=fsreadfilepath>` (modern)

## Related Issues

Fixes https://github.com/nodejs/doc-kit/issues/697

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
