### PR TITLE
docs: add local development guide to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thank you for your interest in contributing to the `@node-core/doc-kit` project!
 - [Getting Started](#getting-started)
   - [Prerequisites](#prerequisites)
   - [Setting Up Your Development Environment](#setting-up-your-development-environment)
+  - [Running the Tool Locally](#running-the-tool-locally)
 - [Development Workflow](#development-workflow)
   - [Making Changes](#making-changes)
   - [Submitting Your Changes](#submitting-your-changes)
@@ -67,6 +68,53 @@ The steps below will give you a general idea of how to prepare your local enviro
    ```bash
    npm install
    ```
+
+### Running the Tool Locally
+
+`doc-kit` generates documentation from the Markdown API docs in the [Node.js repository](https://github.com/nodejs/node). To run the tool locally, you need a copy of those source files.
+
+1. **Get the Node.js API docs (sparse checkout)**
+
+   You only need a few directories from the Node.js repo. A sparse checkout avoids downloading the entire repository:
+
+   ```bash
+   git clone --depth 1 --sparse https://github.com/nodejs/node.git ../node
+   cd ../node
+   git sparse-checkout set doc/api lib CHANGELOG.md
+   cd ../doc-kit
+   ```
+
+2. **Run the tool against a single file**
+
+   For fast iteration during development, target a single Markdown file instead of all API docs:
+
+   ```bash
+   node bin/cli.mjs generate \
+     -t legacy-html \
+     -i ../node/doc/api/fs.md \
+     -o out \
+     --index ../node/doc/api/index.md \
+     -c ../node/CHANGELOG.md
+   ```
+
+   The three flags `-i` (input), `-t` (target generator), and `-o` (output directory) are effectively required. Without them the tool either crashes or silently does nothing.
+
+3. **View the generated output**
+
+   ```bash
+   npx serve out
+   ```
+
+4. **Use debug logging**
+
+   Add `--log-level debug` before the `generate` subcommand to see the full pipeline trace:
+
+   ```bash
+   node bin/cli.mjs --log-level debug generate -t legacy-html -i ../node/doc/api/fs.md -o out
+   ```
+
+> [!TIP]
+> See the [README](README.md) for the full list of available generators and CLI options.
 
 ## Development Workflow
 


### PR DESCRIPTION
## Description

Add a "Running the Tool Locally" section to CONTRIBUTING.md that explains the practical steps needed to run doc-kit against real Node.js API docs during development.

The current contributing guide covers fork/clone/install/test but doesn't explain how to actually run the tool end-to-end, which is a common stumbling block for new contributors (see also #400).

### What's added

- How to get Node.js API docs via sparse checkout (avoids cloning the full repo)
- The minimum `generate` command with the three effectively-required flags (`-i`, `-t`, `-o`)
- How to view generated output with `npx serve`
- How to use `--log-level debug` for development

## Validation

- Verified Prettier formatting passes
- No code changes, documentation only

## Related Issues

Addresses the documentation gap noted in #400

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
