### PR TITLE
fix(legacy-html): preserve legacy anchor links via slugger

### DIFF
--- a/src/generators/legacy-html/utils/__tests__/slugger.test.mjs
+++ b/src/generators/legacy-html/utils/__tests__/slugger.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createLegacySlugger } from '../slugger.mjs';
+
+describe('createLegacySlugger', () => {
+  it('generates prefix_slug format', () => {
+    const slug = createLegacySlugger();
+    assert.strictEqual(slug('File System', 'fs'), 'fs_file_system');
+  });
+
+  it('strips special characters', () => {
+    const slug = createLegacySlugger();
+    assert.strictEqual(slug('fs.readFile()', 'fs'), 'fs_fs_readfile');
+  });
+
+  it('deduplicates repeated slugs with counter suffix', () => {
+    const slug = createLegacySlugger();
+    assert.strictEqual(slug('File System', 'fs'), 'fs_file_system');
+    assert.strictEqual(slug('File System', 'fs'), 'fs_file_system_1');
+    assert.strictEqual(slug('File System', 'fs'), 'fs_file_system_2');
+  });
+
+  it('each slugger instance has independent state', () => {
+    const slug1 = createLegacySlugger();
+    const slug2 = createLegacySlugger();
+    slug1('File System', 'fs');
+    assert.strictEqual(slug2('File System', 'fs'), 'fs_file_system');
+  });
+
+  it('prevents slugs from starting with a digit', () => {
+    const slug = createLegacySlugger();
+    const result = slug('123abc', 'fs');
+    assert.match(result, /^[^0-9]/);
+  });
+
+  it('handles empty text gracefully', () => {
+    const slug = createLegacySlugger();
+    assert.strictEqual(slug('', 'fs'), 'fs_section');
+  });
+
+  it('trims whitespace from text before generating slug', () => {
+    const slug = createLegacySlugger();
+    assert.strictEqual(slug('  readFile  ', 'fs'), 'fs_readfile');
+  });
+
+  it('collapses multiple special characters into single underscores', () => {
+    const slug = createLegacySlugger();
+    assert.strictEqual(slug('read---file!!!', 'fs'), 'fs_read_file');
+  });
+});

--- a/src/generators/legacy-html/utils/buildContent.mjs
+++ b/src/generators/legacy-html/utils/buildContent.mjs
@@ -5,6 +5,7 @@ import { u as createTree } from 'unist-builder';
 import { SKIP, visit } from 'unist-util-visit';
 
 import buildExtraContent from './buildExtraContent.mjs';
+import { createLegacySlugger } from './slugger.mjs';
 import getConfig from '../../../utils/configuration/index.mjs';
 import {
   GITHUB_BLOB_URL,
@@ -20,7 +21,7 @@ import { QUERIES, UNIST } from '../../../utils/queries/index.mjs';
  * @param {import('unist').Parent} parent The parent node of the current node
  * @returns {import('hast').Element} The HTML AST tree of the heading content
  */
-const buildHeading = ({ data, children, depth }, index, parent) => {
+const buildHeading = ({ data, children, depth }, index, parent, legacySlug) => {
   // Creates the heading element with the heading text and the link to the heading
   const headingElement = createElement(`h${depth + 1}`, [
     // The inner Heading markdown content is still using Remark nodes, and they need
@@ -32,6 +33,12 @@ const buildHeading = ({ data, children, depth }, index, parent) => {
       'span',
       createElement(`a.mark#${data.slug}`, { href: `#${data.slug}` }, '#')
     ),
+    // adds a hidden legacy anchor to preserve old external links
+    createElement('a', {
+      id: legacySlug,
+      'aria-hidden': 'true',
+      class: 'legacy',
+    }),
   ]);
 
   // Removes the original Heading node from the content tree
@@ -221,6 +228,7 @@ const buildMetadataElement = (node, remark) => {
  */
 export default (headNodes, metadataEntries, remark) => {
   // Creates the root node for the content
+  const getLegacySlug = createLegacySlugger();
   const parsedNodes = createTree(
     'root',
     // Parses the metadata pieces of each node and the content
@@ -229,7 +237,14 @@ export default (headNodes, metadataEntries, remark) => {
       const content = structuredClone(entry.content);
 
       // Parses the Heading nodes into Heading elements
-      visit(content, UNIST.isHeading, buildHeading);
+      visit(content, UNIST.isHeading, (node, index, parent) =>
+        buildHeading(
+          node,
+          index,
+          parent,
+          getLegacySlug(node.data.text, entry.api)
+        )
+      );
 
       // Parses the Blockquotes into Stability elements
       // This is treated differently as we want to preserve the position of a Stability Index

--- a/src/generators/legacy-html/utils/slugger.mjs
+++ b/src/generators/legacy-html/utils/slugger.mjs
@@ -1,0 +1,23 @@
+'use strict';
+
+/**
+ * creates a stateful slugger for legacy anchor links
+ *
+ * generates underscore-separated slugs in the form `{apiStem}_{text}`,
+ * appending `_{n}` for duplicates to preserve historical anchor compatibility
+ *
+ * @returns {(text: string, apiStem: string) => string}
+ */
+export const createLegacySlugger =
+  (counters = {}) =>
+  (text, apiStem) => {
+    const base = (text || 'section').trim();
+    const id = `${apiStem}_${base}`
+      .toLowerCase()
+      .replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '')
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^\d/, '_$&');
+    counters[id] ??= -1;
+    const count = ++counters[id];
+    return count > 0 ? `${id}_${count}` : id;
+  };


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Restores the legacy HTML anchor alias to preserve backward-compatible links.  
Some projects, including Express, still depend on these anchors, and external documentation may also be relying on them.  
This adds a stateful slugger (`createLegacySlugger`) that appends `_n` to duplicates and integrates it into the legacy HTML generator.
This only modifies the legacy HTML generator and does not affect the modern generator.

## Validation

- Added unit tests for `createLegacySlugger` covering:
  - Prefix + underscore slug generation
  - Special character stripping
  - Duplicate slug deduplication
  - Independent state per slugger instance
  - Handling of numeric-first headings
- `npm run test` passes all tests
- Legacy HTML output now includes hidden anchors with the legacy ID

## Related Issues

Fixes #697

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have checked code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.

Note: I've noticed another contributor had started work on this, but progress has been paused. This PR provides a complete implementation for legacy anchor slug handling.