### PR TITLE
fix(web): remove v prefix from version in page title

### DIFF
--- a/src/generators/web/index.mjs
+++ b/src/generators/web/index.mjs
@@ -30,7 +30,7 @@ export default createLazyGenerator({
   defaultConfiguration: {
     templatePath: join(import.meta.dirname, 'template.html'),
     project: 'Node.js',
-    title: '{project} v{version} Documentation',
+    title: '{project} {version} Documentation',
     useAbsoluteURLs: false,
     editURL: `${GITHUB_EDIT_URL}/doc/api{path}.md`,
     pageURL: '{baseURL}/latest-{version}/api{path}.html',


### PR DESCRIPTION
The page title currently renders as "Node.js v25.4.0 Documentation". The Node.js documentation style guide specifies that version references should not include the `v` prefix.

Removes the `v` from the template string in `processJSXEntries` so the title renders as "Node.js 25.4.0 Documentation".

Fixes #722