### PR TITLE
fix(metadata): preserve underscores in generated anchor IDs

### DIFF
--- a/src/generators/metadata/constants.mjs
+++ b/src/generators/metadata/constants.mjs
@@ -6,7 +6,7 @@ export const IGNORE_STABILITY_STEMS = ['documentation'];
 export const DOC_API_SLUGS_REPLACEMENTS = [
   { from: /node.js/i, to: 'nodejs' }, // Replace Node.js
   { from: /&/, to: '-and-' }, // Replace &
-  { from: /[/_,:;\\ ]/g, to: '-' }, // Replace /_,:;\. and whitespace
+  { from: /[/,:;\\ ]/g, to: '-' }, // Replace /,:;\. and whitespace
   { from: /^-+(?!-*$)/g, to: '' }, // Remove any leading hyphens
   { from: /(?<!^-*)-+$/g, to: '' }, // Remove any trailing hyphens
   { from: /^(?!-+$).*?(--+)/g, to: '-' }, // Replace multiple hyphens

--- a/src/generators/metadata/utils/__tests__/slugger.test.mjs
+++ b/src/generators/metadata/utils/__tests__/slugger.test.mjs
@@ -25,8 +25,8 @@ describe('slug', () => {
   });
 
   describe('special character to hyphen replacement', () => {
-    it('replaces underscores with hyphens', () => {
-      assert.strictEqual(slug('foo_bar', identity), 'foo-bar');
+    it('preserves underscores', () => {
+      assert.strictEqual(slug('foo_bar', identity), 'foo_bar');
     });
 
     it('replaces forward slashes with hyphens', () => {
@@ -85,8 +85,8 @@ describe('slug', () => {
       assert.strictEqual(slug('Hello World'), 'hello-world');
     });
 
-    it('converts underscored names to hyphenated slugs', () => {
-      assert.strictEqual(slug('child_process'), 'child-process');
+    it('preserves underscores in module names', () => {
+      assert.strictEqual(slug('child_process'), 'child_process');
     });
 
     it('handles titles with no special characters', () => {


### PR DESCRIPTION

<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The DOC_API_SLUGS_REPLACEMENTS regex was converting underscores to dashes, breaking internal links across the Node.js docs

Tested by generating all 68  doc files, it fixes 16 docs.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues
REFS: https://github.com/nodejs/node/issues/62580

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
