### PR TITLE
docs: add AGENTS.md with Cursor Cloud specific instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,14 +13,14 @@ This is the Node.js API documentation generator (`@node-core/doc-kit`). It is a 
 
 All standard dev commands are in `package.json` `scripts` and documented in `CONTRIBUTING.md`:
 
-| Task | Command |
-|---|---|
-| Install deps | `npm install` |
-| Lint | `node --run lint` |
-| Format check | `node --run format` |
-| Tests | `node --run test` |
+| Task             | Command                    |
+| ---------------- | -------------------------- |
+| Install deps     | `npm install`              |
+| Lint             | `node --run lint`          |
+| Format check     | `node --run format`        |
+| Tests            | `node --run test`          |
 | Tests + coverage | `node --run test:coverage` |
-| Run CLI | `node bin/cli.mjs` |
+| Run CLI          | `node bin/cli.mjs`         |
 
 ### Running the tool locally
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is the Node.js API documentation generator (`@node-core/doc-kit`). It is a single-package Node.js CLI tool (no monorepo, no Docker, no external services).
+
+### Runtime
+
+- Requires **Node.js 24** (see `.nvmrc`). Use `nvm install 24 && nvm use 24` if not already active.
+- Package manager is **npm** (lockfile: `package-lock.json`).
+
+### Key commands
+
+All standard dev commands are in `package.json` `scripts` and documented in `CONTRIBUTING.md`:
+
+| Task | Command |
+|---|---|
+| Install deps | `npm install` |
+| Lint | `node --run lint` |
+| Format check | `node --run format` |
+| Tests | `node --run test` |
+| Tests + coverage | `node --run test:coverage` |
+| Run CLI | `node bin/cli.mjs` |
+
+### Running the tool locally
+
+To actually generate docs you need Node.js API markdown sources. Sparse-clone them:
+
+```bash
+git clone --depth 1 --sparse https://github.com/nodejs/node.git /tmp/node
+cd /tmp/node && git sparse-checkout set --skip-checks doc/api lib CHANGELOG.md
+```
+
+Then run against a single file for fast iteration:
+
+```bash
+node bin/cli.mjs generate -t legacy-html -i /tmp/node/doc/api/fs.md -o /tmp/out --index /tmp/node/doc/api/index.md -c /tmp/node/CHANGELOG.md
+```
+
+### Non-obvious caveats
+
+- The `git sparse-checkout set` command needs `--skip-checks` when including individual files like `CHANGELOG.md` (not directories).
+- Pre-commit hook (`npx lint-staged`) runs ESLint + Prettier on staged `.js`/`.mjs`/`.jsx` files. Use `--no-verify` to bypass if needed.
+- Tests use Node.js built-in test runner with `--experimental-test-module-mocks` flag (already configured in `package.json` scripts).
+- ESLint produces 2 warnings in `src/generators/web/ui/hooks/useOrama.mjs` — these are pre-existing and not errors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This is the Node.js API documentation generator (`@node-core/doc-kit`). It is a 
 
 ### Runtime
 
-- Requires **Node.js 24** (see `.nvmrc`). Use `nvm install 24 && nvm use 24` if not already active.
+- Requires the **Node.js LTS** version specified in `.nvmrc`. Use `nvm install --lts && nvm use --lts` if not already active.
 - Package manager is **npm** (lockfile: `package-lock.json`).
 
 ### Key commands


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `AGENTS.md` with Cursor Cloud specific instructions for setting up and developing in this codebase. This file documents:

- Runtime requirements (Node.js 24)
- Key dev commands (lint, test, format, run CLI)
- How to run the tool locally with sparse-cloned Node.js API docs
- Non-obvious caveats discovered during setup

## Validation

Full development environment verified:

- **Node.js 24** installed and active (per `.nvmrc`)
- **npm install** completed successfully
- **Lint** passes (0 errors, 2 pre-existing warnings)
- **Format check** passes
- **All 403 tests pass** (0 failures)
- **CLI runs end-to-end**: generated both `legacy-html` and `web` output for `fs.md`

[Generated Node.js fs module docs (web generator)](https://cursor.com/agents/bc-c145500e-0076-494e-8c53-78467909b4fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgenerated_docs_fs_module.webp)

Test results (403/403 passing):
[test_output.log](https://cursor.com/agents/bc-c145500e-0076-494e-8c53-78467909b4fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_output.log)

## Related Issues

N/A — Development environment setup

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c145500e-0076-494e-8c53-78467909b4fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c145500e-0076-494e-8c53-78467909b4fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

