### PR TITLE
feat(ast): strip /index suffix from path when index files are used

### DIFF
--- a/src/generators/ast/__tests__/generate.test.mjs
+++ b/src/generators/ast/__tests__/generate.test.mjs
@@ -1,0 +1,70 @@
+'use strict';
+
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+// Mock fs/promises so processChunk doesn't touch the real filesystem
+mock.module('node:fs/promises', {
+  namedExports: {
+    readFile: async () => '# Hello',
+  },
+});
+
+// Mock remark to avoid parsing overhead
+mock.module('../../../utils/remark.mjs', {
+  namedExports: {
+    getRemark: () => ({ parse: () => ({ type: 'root', children: [] }) }),
+  },
+});
+
+// Mock queries to avoid regex replacements interfering
+mock.module('../../../utils/queries/index.mjs', {
+  namedExports: {
+    QUERIES: {
+      standardYamlFrontmatter: /(?!x)x/, // never matches
+      stabilityIndexPrefix: /(?!x)x/, // never matches
+    },
+  },
+});
+
+const { processChunk } = await import('../generate.mjs');
+
+describe('processChunk path computation', () => {
+  it('strips /index suffix from a top-level index file', async () => {
+    const results = await processChunk([['doc/api/index.md', 'doc/api']], [0]);
+    assert.strictEqual(results[0].path, '/');
+  });
+
+  it('strips /index suffix from a nested index file', async () => {
+    const results = await processChunk(
+      [['doc/api/sub/index.md', 'doc/api']],
+      [0]
+    );
+    assert.strictEqual(results[0].path, '/sub');
+  });
+
+  it('keeps path unchanged for non-index files', async () => {
+    const results = await processChunk([['doc/api/fs.md', 'doc/api']], [0]);
+    assert.strictEqual(results[0].path, '/fs');
+  });
+
+  it('keeps path unchanged for files whose name contains index but is not index', async () => {
+    const results = await processChunk(
+      [['doc/api/indexes.md', 'doc/api']],
+      [0]
+    );
+    assert.strictEqual(results[0].path, '/indexes');
+  });
+
+  it('processes multiple files correctly', async () => {
+    const input = [
+      ['doc/api/index.md', 'doc/api'],
+      ['doc/api/fs.md', 'doc/api'],
+      ['doc/api/sub/index.md', 'doc/api'],
+    ];
+    const results = await processChunk(input, [0, 1, 2]);
+    assert.strictEqual(results[0].path, '/');
+    assert.strictEqual(results[1].path, '/fs');
+    assert.strictEqual(results[2].path, '/sub');
+  });
+});

--- a/src/generators/ast/generate.mjs
+++ b/src/generators/ast/generate.mjs
@@ -35,11 +35,16 @@ export async function processChunk(inputSlice, itemIndices) {
         match => `[${match}](${STABILITY_INDEX_URL})`
       );
 
-    const relativePath = sep + withExt(relative(parent, path));
+    const strippedPath = withExt(relative(parent, path));
+    // Treat index files as the directory root (e.g. /index → /, /api/index → /api)
+    const relativePath =
+      strippedPath === 'index'
+        ? sep
+        : sep + strippedPath.replace(/(\/|^)index$/, '');
 
     results.push({
       tree: remark().parse(value),
-      // The path is the relative path minus the extension
+      // The path is the relative path minus the extension (and /index suffix)
       path: relativePath,
     });
   }

--- a/src/generators/metadata/utils/parse.mjs
+++ b/src/generators/metadata/utils/parse.mjs
@@ -42,7 +42,8 @@ export const parseApiDoc = ({ path, tree }, typeMap) => {
   const nodeSlugger = createNodeSlugger();
 
   // Slug the API (We use a non-class slugger, since we are fairly certain that `path` is unique)
-  const api = slug(path.slice(1).replace(sep, '-'));
+  // When path is the root ('/'), the file is an index and the api identifier falls back to 'index'
+  const api = slug(path.slice(1).replace(sep, '-')) || 'index';
 
   // Get all Markdown Footnote definitions from the tree
   const markdownDefinitions = selectAll('definition', tree);
@@ -83,7 +84,7 @@ export const parseApiDoc = ({ path, tree }, typeMap) => {
     const metadata = /** @type {import('../types').MetadataEntry} */ ({
       api,
       path,
-      basename: basename(path),
+      basename: basename(path) || 'index',
       heading: headingNode,
     });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

When parsing markdown files, the `path` property on the resulting AST node was including `/index` for index files (e.g. `index.md` → `/index`, `api/index.md` → `/api/index`). This changes the behavior so index files resolve to their parent directory path:

- `index.md` → `path: /`
- `api/index.md` → `path: /api`
- `api/fs.md` → `path: /api/fs` (unchanged)

The fix is in `src/generators/ast/generate.mjs` in the `processChunk` function, where the `relativePath` is computed from the file path relative to the glob parent.

Additionally, `src/generators/metadata/utils/parse.mjs` is updated so that the `api` and `basename` identifiers (derived from `path`) fall back to `'index'` when `path === '/'`. This preserves correct behavior for all downstream generators that use `api`/`basename` as file identifiers (e.g. `legacy-json` writing `index.json`, `legacy-json-all` skipping the index section, `legacy-html` writing `index.html`, `web` generator using `basename.html` for navigation).

## Validation

A new test file `src/generators/ast/__tests__/generate.test.mjs` was added with 5 test cases covering:
- Top-level index file (`/index.md` → `/`)
- Nested index file (`sub/index.md` → `/sub`)
- Non-index files (unchanged)
- Files whose name contains "index" but isn't exactly "index" (e.g. `indexes.md`, unchanged)
- Multiple files processed together

All 408 tests in the test suite pass.

## Related Issues

<!-- N/A -->

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25c01f21-70a3-4334-83fb-7eadcdf71a65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25c01f21-70a3-4334-83fb-7eadcdf71a65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

