### PR TITLE
refactor: fetch orama-db.json when search triggered

### DIFF
--- a/src/generators/web/ui/hooks/useOrama.mjs
+++ b/src/generators/web/ui/hooks/useOrama.mjs
@@ -27,7 +27,10 @@ export default pathname => {
       if (!loaded.current) {
         loaded.current = fetch(relativeOrAbsolute('/orama-db.json', pathname))
           .then(response => response.ok && response.json())
-          .then(data => load(db, data));
+          .then(data => load(db, data))
+          .catch(() => {
+            loaded.current = null;
+          });
       }
 
       return loaded.current;

--- a/src/generators/web/ui/hooks/useOrama.mjs
+++ b/src/generators/web/ui/hooks/useOrama.mjs
@@ -1,15 +1,17 @@
 import { create, search, load } from '@orama/orama';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 import { relativeOrAbsolute } from '../utils/relativeOrAbsolute.mjs';
 
 /**
- * Hook for initializing and managing Orama search database
+ * Hook for initializing and managing Orama search database.
+ * The search data is lazily fetched on the first search call.
  *
  * @param {string} pathname - The current page's path (e.g., '/api/fs')
  */
 export default pathname => {
   const [client, setClient] = useState(null);
+  const loaded = useRef(null);
 
   useEffect(() => {
     // Create the database instance
@@ -17,18 +19,30 @@ export default pathname => {
       schema: {},
     });
 
+    /**
+     * Ensures the search data is loaded.
+     * @returns {Promise<void>} A promise that resolves when the data is loaded.
+     */
+    const ensureLoaded = () => {
+      if (!loaded.current) {
+        loaded.current = fetch(relativeOrAbsolute('/orama-db.json', pathname))
+          .then(response => response.ok && response.json())
+          .then(data => load(db, data));
+      }
+
+      return loaded.current;
+    };
+
     // TODO(@avivkeller): Ask Orama to support this functionality natively
     /**
      * @param {any} options
      */
-    db.search = options => search(db, options);
+    db.search = async options => {
+      await ensureLoaded();
+      return search(db, options);
+    };
 
     setClient(db);
-
-    // Load the search data
-    fetch(relativeOrAbsolute('/orama-db.json', pathname))
-      .then(response => response.ok && response.json())
-      .then(data => load(db, data));
   }, []);
 
   return client;


### PR DESCRIPTION
## Description

Since we're not using Orama Cloud with `doc-kit`, the generated files end up being quite large. With this change, we'll fetch the required file only when search is triggered, avoiding downloading this large file unnecessarily.

For example, on the https://nodejs.org/learn page, the total download size is around ≈ 470kB, and about ≈ 250kB of that comes from `orama-db.json`. Considering that it's not certain whether the user will even use the search feature, this overhead feels quite significant;

<img width="800" alt="image" src="https://github.com/user-attachments/assets/6a359773-5e96-4ece-9eb6-c6c64b27aa0f" />

## Validation

Everything should work smoothly in the preview. It would be good to throttle the network (e.g., simulate a slow connection) and verify that there are no noticeable slowdowns.

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
