### PR TITLE
fix: correct JSDoc

### DIFF
--- a/src/utils/generators.mjs
+++ b/src/utils/generators.mjs
@@ -61,7 +61,6 @@ export const coerceSemVer = version => {
  *
  * @param {string | import('semver').SemVer} introduced
  * @param {Array<import('../parsers/types').ReleaseEntry>} releases
- * @param {Boolean} [includeNonMajor=false]
  * @returns {Array<import('../parsers/types').ReleaseEntry>}
  */
 export const getCompatibleVersions = (introduced, releases) => {

--- a/src/utils/url.mjs
+++ b/src/utils/url.mjs
@@ -1,7 +1,7 @@
 /**
  * Kind of like `path.posix.relative`, however, this functions more like a URL resolution
- * @param {string} from
  * @param {string} to
+ * @param {string} from
  * @returns {string}
  */
 export const relative = (to, from) => {


### PR DESCRIPTION
## Description

#### This PR fixes minor JSDoc mismatches:

- Reordered the JSDocs parameters of `relative` in file `src/utils/url.mjs` to match function signature.
- Removed an unused `@param` (`includeNonMajor`) from the JSDoc of `getCompatibleVersions` in `src/utils/generators.mjs` since it doesn't exist in the function signature.

## Validation

Confirmed that no functional logic was changed.

## Related Issues

No Related Issues.

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `node --run test` and all tests passed.
- [X] I have check code formatting with `node --run format` & `node --run lint`.
- [X] I've covered new added functionality with unit tests if necessary.
