### PR TITLE
fix(legacy-html): prevent partial nav class matches

### DIFF
--- a/src/generators/legacy-html/generate.mjs
+++ b/src/generators/legacy-html/generate.mjs
@@ -35,8 +35,8 @@ export async function processChunk(slicedInput, itemIndices, navigation) {
     const { head, nodes, headNodes } = slicedInput[idx];
 
     const nav = navigation.replace(
-      `class="nav-${head.api}`,
-      `class="nav-${head.api} active`
+      `class="nav-${head.api}"`,
+      `class="nav-${head.api} active"`
     );
 
     const toc = String(


### PR DESCRIPTION
## Description

The previous `.replace()` logic used a partial match (`class="nav-${head.api}`). For APIs like `stream`, the partial string `class="nav-stream` would incorrectly match the first occurrence it found, which happens to be `class="nav-stream_iter"`. This resulted in corrupted class names `class="active_iter  nav-stream"` and left the actual `stream` link unmodified:

<img width="544" height="387" alt="Screenshot from 2026-04-11 12-58-24" src="https://github.com/user-attachments/assets/885be3d9-3b91-485b-9321-f066acf853eb" />

The same for  `Modules: node:module API`:

<img width="544" height="387" alt="Screenshot from 2026-04-11 12-59-18" src="https://github.com/user-attachments/assets/ec83cd18-3081-4406-bb54-1b0b782942ac" />

**The Fix:**

Added closing double-quotes to the search and replace strings to enforce an exact match (`class="nav-${head.api}"`).

## Validation

- Generated the `legacy-html` docs locally.
- Verified that the `Stream` and `Modules: node:module API` sidebar links are now correctly bolded (`active` class applied).

## Related Issues

#761 

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `node --run test` and all tests passed.
- [X] I have check code formatting with `node --run format` & `node --run lint`.
- [X] I've covered new added functionality with unit tests if necessary.
