### PR TITLE
feat(metadata): support advanced generics using recursion

### DIFF
--- a/src/generators/metadata/constants.mjs
+++ b/src/generators/metadata/constants.mjs
@@ -56,8 +56,5 @@ export const DOC_API_HEADING_TYPES = [
   },
 ];
 
-// This regex is used to match basic TypeScript generic types (e.g., Promise<string>)
-export const TYPE_GENERIC_REGEX = /^([^<]+)<([^>]+)>$/;
-
 // This is the base URL of the Man7 documentation
 export const DOC_MAN_BASE_URL = 'http://man7.org/linux/man-pages/man';

--- a/src/generators/metadata/constants.mjs
+++ b/src/generators/metadata/constants.mjs
@@ -1,3 +1,7 @@
+// These openers/closers are used to determine if a type string is well-formed
+export const TYPE_OPENERS = new Set(['<', '(', '{', '[']);
+export const TYPE_CLOSERS = new Set(['>', ')', '}', ']']);
+
 // On "About this Documentation", we define the stability indices, and thus
 // we don't need to check it for stability references
 export const IGNORE_STABILITY_STEMS = ['documentation'];

--- a/src/generators/metadata/utils/__tests__/transformers.test.mjs
+++ b/src/generators/metadata/utils/__tests__/transformers.test.mjs
@@ -79,7 +79,7 @@ describe('transformTypeToReferenceLink', () => {
   it('should transform a function returning a Generic type', () => {
     strictEqual(
       transformTypeToReferenceLink('(err: Error) => Promise<boolean>', {}),
-      '(err: Error) =&gt; [`<Promise>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[`<boolean>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#boolean_type)&gt;'
+      '(err: [`<Error>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error)) =&gt; [`<Promise>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[`<boolean>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#boolean_type)&gt;'
     );
   });
 
@@ -90,12 +90,26 @@ describe('transformTypeToReferenceLink', () => {
     );
   });
 
-  it('should handle extreme nested combinations of functions, generics, unions, and intersections', () => {
+  it('should handle extreme nested combinations of functions, arrays, generics, unions, and intersections', () => {
     const input =
-      '(str: MyType) => Promise<Map<string, number & string>, Map<string | number>>';
+      '(str: string[]) => Promise<Map<string, number & string>, Map<string | number>>';
+
     const expected =
-      '(str: MyType) =&gt; [`<Promise>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[`<Map>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map)&lt;[`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type), [`<number>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#number_type) & [`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type)&gt;, [`<Map>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map)&lt;[`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type) | [`<number>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#number_type)&gt;&gt;';
+      '(str: [`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type)[]) =&gt; [`<Promise>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[`<Map>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map)&lt;[`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type), [`<number>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#number_type) & [`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type)&gt;, [`<Map>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map)&lt;[`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type) | [`<number>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#number_type)&gt;&gt;';
 
     strictEqual(transformTypeToReferenceLink(input, {}), expected);
+  });
+
+  it('should parse functions with array destructuring in callbacks returning functions with object destructuring', () => {
+    const input =
+      '(cb: ([first, second]: string[]) => void) => ({ id, name }: User) => boolean';
+
+    const expected =
+      '(cb: ([first, second]: [`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type)[]) =&gt; `<void>`) =&gt; ({ id, name }: [`<User>`](userLink)) =&gt; [`<boolean>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#boolean_type)';
+
+    strictEqual(
+      transformTypeToReferenceLink(input, { User: 'userLink' }),
+      expected
+    );
   });
 });

--- a/src/generators/metadata/utils/__tests__/transformers.test.mjs
+++ b/src/generators/metadata/utils/__tests__/transformers.test.mjs
@@ -75,4 +75,27 @@ describe('transformTypeToReferenceLink', () => {
       '[`<Map>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map)&lt;[`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type), [`<number>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#number_type)&gt; & [`<Array>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type)&gt;'
     );
   });
+
+  it('should transform a function returning a Generic type', () => {
+    strictEqual(
+      transformTypeToReferenceLink('(err: Error) => Promise<boolean>', {}),
+      '(err: Error) =&gt; [`<Promise>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[`<boolean>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#boolean_type)&gt;'
+    );
+  });
+
+  it('should respect precedence: Unions (|) are weaker than Intersections (&)', () => {
+    strictEqual(
+      transformTypeToReferenceLink('string | number & boolean', {}),
+      '[`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type) | [`<number>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#number_type) & [`<boolean>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#boolean_type)'
+    );
+  });
+
+  it('should handle extreme nested combinations of functions, generics, unions, and intersections', () => {
+    const input =
+      '(str: MyType) => Promise<Map<string, number & string>, Map<string | number>>';
+    const expected =
+      '(str: MyType) =&gt; [`<Promise>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[`<Map>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map)&lt;[`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type), [`<number>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#number_type) & [`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type)&gt;, [`<Map>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map)&lt;[`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type) | [`<number>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#number_type)&gt;&gt;';
+
+    strictEqual(transformTypeToReferenceLink(input, {}), expected);
+  });
 });

--- a/src/generators/metadata/utils/transformers.mjs
+++ b/src/generators/metadata/utils/transformers.mjs
@@ -1,5 +1,6 @@
 import { DOC_MAN_BASE_URL, DOC_API_HEADING_TYPES } from '../constants.mjs';
 import { slug } from './slugger.mjs';
+import { parseType } from './typeParser.mjs';
 import { transformNodesToString } from '../../../utils/unist.mjs';
 import BUILTIN_TYPE_MAP from '../maps/builtin.json' with { type: 'json' };
 import MDN_TYPE_MAP from '../maps/mdn.json' with { type: 'json' };
@@ -17,129 +18,6 @@ export const transformUnixManualToLink = (
   sectionLetter = ''
 ) => {
   return `[\`${text}\`](${DOC_MAN_BASE_URL}${sectionNumber}/${command}.${sectionNumber}${sectionLetter}.html)`;
-};
-
-/**
- * Safely splits a string by a given set of separators at depth 0 (ignoring those inside < > or ( )).
- *
- * @param {string} str The string to split
- * @param {string} separator The separator to split by (e.g., '|', '&', ',', '=>')
- * @returns {string[]} The split pieces
- */
-const splitByOuterSeparator = (str, separator) => {
-  const pieces = [];
-  let current = '';
-  let depth = 0;
-
-  for (let i = 0; i < str.length; i++) {
-    const char = str[i];
-
-    // Track depth using brackets and parentheses
-    if (char === '<' || char === '(') {
-      depth++;
-    } else if ((char === '>' && str[i - 1] !== '=') || char === ')') {
-      depth--;
-    }
-
-    // Check for multi-character separators like '=>'
-    const isArrow = separator === '=>' && char === '=' && str[i + 1] === '>';
-    // Check for single-character separators
-    const isCharSeparator = separator === char;
-
-    if (depth === 0 && (isCharSeparator || isArrow)) {
-      pieces.push(current.trim());
-      current = '';
-      if (isArrow) {
-        i++;
-      } // skip the '>' part of '=>'
-      continue;
-    }
-
-    current += char;
-  }
-
-  pieces.push(current.trim());
-  return pieces;
-};
-
-/**
- * Recursively parses advanced TypeScript types, including Unions, Intersections, Functions, and Nested Generics.
- * * @param {string} typeString The plain type string to evaluate
- * @param {Function} transformType The function used to resolve individual types into links
- * @returns {string|null} The formatted Markdown link(s), or null if the base type doesn't map
- */
-const parseAdvancedType = (typeString, transformType) => {
-  const trimmed = typeString.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  // Handle Unions (|)
-  if (trimmed.includes('|')) {
-    const parts = splitByOuterSeparator(trimmed, '|');
-    if (parts.length > 1) {
-      // Re-evaluate each part recursively and join with ' | '
-      const resolvedParts = parts.map(
-        p => parseAdvancedType(p, transformType) || `\`<${p}>\``
-      );
-      return resolvedParts.join(' | ');
-    }
-  }
-
-  // Handle Intersections (&)
-  if (trimmed.includes('&')) {
-    const parts = splitByOuterSeparator(trimmed, '&');
-    if (parts.length > 1) {
-      // Re-evaluate each part recursively and join with ' & '
-      const resolvedParts = parts.map(
-        p => parseAdvancedType(p, transformType) || `\`<${p}>\``
-      );
-      return resolvedParts.join(' & ');
-    }
-  }
-
-  // Handle Functions (=>)
-  if (trimmed.includes('=>')) {
-    const parts = splitByOuterSeparator(trimmed, '=>');
-    if (parts.length === 2) {
-      const params = parts[0];
-      const returnType = parts[1];
-
-      // Preserve the function signature, just link the return type for now
-      // (Mapping param types inside the signature string is complex and often unnecessary for simple docs)
-      const parsedReturn =
-        parseAdvancedType(returnType, transformType) || `\`<${returnType}>\``;
-      return `${params} =&gt; ${parsedReturn}`;
-    }
-  }
-
-  // 3. Handle Generics (Base<Inner, Inner>)
-  if (trimmed.includes('<') && trimmed.endsWith('>')) {
-    const firstBracketIndex = trimmed.indexOf('<');
-    const baseType = trimmed.slice(0, firstBracketIndex).trim();
-    const innerType = trimmed.slice(firstBracketIndex + 1, -1).trim();
-
-    const baseResult = transformType(baseType.replace(/\[\]$/, ''));
-    const baseFormatted = baseResult
-      ? `[\`<${baseType}>\`](${baseResult})`
-      : `\`<${baseType}>\``;
-
-    // Split arguments safely by comma
-    const innerArgs = splitByOuterSeparator(innerType, ',');
-    const innerFormatted = innerArgs
-      .map(arg => parseAdvancedType(arg, transformType) || `\`<${arg}>\``)
-      .join(', ');
-
-    return `${baseFormatted}&lt;${innerFormatted}&gt;`;
-  }
-
-  // Base Case: Plain Type (e.g., string, Buffer, Function)
-  const result = transformType(trimmed.replace(/\[\]$/, ''));
-  if (trimmed.length && result) {
-    return `[\`<${trimmed}>\`](${result})`;
-  }
-
-  return null;
 };
 
 /**
@@ -192,8 +70,7 @@ export const transformTypeToReferenceLink = (type, record) => {
     return '';
   };
 
-  // Kick off the recursive parser on the cleaned input
-  const markdownLinks = parseAdvancedType(typeInput, transformType);
+  const markdownLinks = parseType(typeInput, transformType);
 
   // Return the replaced links or the original content if they all failed to be replaced
   // Note that if some failed to get replaced, only the valid ones will be returned

--- a/src/generators/metadata/utils/transformers.mjs
+++ b/src/generators/metadata/utils/transformers.mjs
@@ -1,8 +1,4 @@
-import {
-  DOC_MAN_BASE_URL,
-  DOC_API_HEADING_TYPES,
-  TYPE_GENERIC_REGEX,
-} from '../constants.mjs';
+import { DOC_MAN_BASE_URL, DOC_API_HEADING_TYPES } from '../constants.mjs';
 import { slug } from './slugger.mjs';
 import { transformNodesToString } from '../../../utils/unist.mjs';
 import BUILTIN_TYPE_MAP from '../maps/builtin.json' with { type: 'json' };
@@ -22,84 +18,134 @@ export const transformUnixManualToLink = (
 ) => {
   return `[\`${text}\`](${DOC_MAN_BASE_URL}${sectionNumber}/${command}.${sectionNumber}${sectionLetter}.html)`;
 };
+
 /**
- * Safely splits the string by `|` or `&` at the top level (ignoring those
- * inside `< >`), and returns both the pieces and the separator used.
+ * Safely splits a string by a given set of separators at depth 0 (ignoring those inside < > or ( )).
  *
- * @param {string} str The type string to split
- * @returns {{ pieces: string[], separator: string }} The split pieces and the separator string used to join them (` | ` or ` & `)
+ * @param {string} str The string to split
+ * @param {string} separator The separator to split by (e.g., '|', '&', ',', '=>')
+ * @returns {string[]} The split pieces
  */
-const splitByOuterSeparator = str => {
+
+/**
+ *
+ */
+const splitByOuterSeparator = (str, separator) => {
   const pieces = [];
   let current = '';
   let depth = 0;
-  let separator;
 
-  for (const char of str) {
-    if (char === '<') {
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    // Track depth using brackets and parentheses
+    if (char === '<' || char === '(') {
       depth++;
-    } else if (char === '>') {
+    } else if (char === '>' || char === ')') {
       depth--;
-    } else if ((char === '|' || char === '&') && depth === 0) {
-      pieces.push(current);
+    }
+
+    // Check for multi-character separators like '=>'
+    const isArrow = separator === '=>' && char === '=' && str[i + 1] === '>';
+    // Check for single-character separators
+    const isCharSeparator = separator === char;
+
+    if (depth === 0 && (isCharSeparator || isArrow)) {
+      pieces.push(current.trim());
       current = '';
-      separator ??= ` ${char} `;
+      if (isArrow) {
+        i++;
+      } // skip the '>' part of '=>'
       continue;
     }
+
     current += char;
   }
 
-  pieces.push(current);
-  return { pieces, separator };
+  pieces.push(current.trim());
+  return pieces;
 };
 
 /**
- * Attempts to parse and format a basic Generic type (e.g., Promise<string>).
- * It also supports union and multi-parameter types within the generic brackets.
- *
- * @param {string} typePiece The plain type piece to be evaluated
+ * Recursively parses advanced TypeScript types, including Unions, Intersections, Functions, and Nested Generics.
+ * * @param {string} typeString The plain type string to evaluate
  * @param {Function} transformType The function used to resolve individual types into links
- * @returns {string|null} The formatted Markdown link, or null if no match is found
+ * @returns {string|null} The formatted Markdown link(s), or null if the base type doesn't map
  */
-const formatBasicGeneric = (typePiece, transformType) => {
-  const genericMatch = typePiece.match(TYPE_GENERIC_REGEX);
+const parseAdvancedType = (typeString, transformType) => {
+  const trimmed = typeString.trim();
+  if (!trimmed) {
+    return null;
+  }
 
-  if (genericMatch) {
-    const baseType = genericMatch[1].trim();
-    const innerType = genericMatch[2].trim();
+  // Handle Unions (|)
+  if (trimmed.includes('|')) {
+    const parts = splitByOuterSeparator(trimmed, '|');
+    if (parts.length > 1) {
+      // Re-evaluate each part recursively and join with ' | '
+      const resolvedParts = parts.map(
+        p => parseAdvancedType(p, transformType) || `\`<${p}>\``
+      );
+      return resolvedParts.join(' | ');
+    }
+  }
+
+  // Handle Intersections (&)
+  if (trimmed.includes('&')) {
+    const parts = splitByOuterSeparator(trimmed, '&');
+    if (parts.length > 1) {
+      // Re-evaluate each part recursively and join with ' & '
+      const resolvedParts = parts.map(
+        p => parseAdvancedType(p, transformType) || `\`<${p}>\``
+      );
+      return resolvedParts.join(' & ');
+    }
+  }
+
+  // Handle Functions (=>)
+  if (trimmed.includes('=>')) {
+    const parts = splitByOuterSeparator(trimmed, '=>');
+    if (parts.length === 2) {
+      const params = parts[0];
+      const returnType = parts[1];
+
+      // Preserve the function signature, just link the return type for now
+      // (Mapping param types inside the signature string is complex and often unnecessary for simple docs)
+      const parsedReturn =
+        parseAdvancedType(returnType, transformType) || `\`<${returnType}>\``;
+      return `${params} =&gt; ${parsedReturn}`;
+    }
+  }
+
+  // 3. Handle Generics (Base<Inner, Inner>)
+  if (trimmed.includes('<') && trimmed.endsWith('>')) {
+    const firstBracketIndex = trimmed.indexOf('<');
+    const baseType = trimmed.slice(0, firstBracketIndex).trim();
+    const innerType = trimmed.slice(firstBracketIndex + 1, -1).trim();
 
     const baseResult = transformType(baseType.replace(/\[\]$/, ''));
     const baseFormatted = baseResult
       ? `[\`<${baseType}>\`](${baseResult})`
       : `\`<${baseType}>\``;
 
-    // Split while capturing delimiters (| or ,) to preserve original syntax
-    const parts = innerType.split(/([|,])/);
-
-    const innerFormatted = parts
-      .map(part => {
-        const trimmed = part.trim();
-        // If it is a delimiter, return it as is
-        if (trimmed === '|') {
-          return ' | ';
-        }
-
-        if (trimmed === ',') {
-          return ', ';
-        }
-
-        const innerRes = transformType(trimmed.replace(/\[\]$/, ''));
-        return innerRes
-          ? `[\`<${trimmed}>\`](${innerRes})`
-          : `\`<${trimmed}>\``;
-      })
-      .join('');
+    // Split arguments safely by comma
+    const innerArgs = splitByOuterSeparator(innerType, ',');
+    const innerFormatted = innerArgs
+      .map(arg => parseAdvancedType(arg, transformType) || `\`<${arg}>\``)
+      .join(', ');
 
     return `${baseFormatted}&lt;${innerFormatted}&gt;`;
   }
 
+  // Base Case: Plain Type (e.g., string, Buffer, Function)
+  const result = transformType(trimmed.replace(/\[\]$/, ''));
+  if (trimmed.length && result) {
+    return `[\`<${trimmed}>\`](${result})`;
+  }
+
   return null;
 };
+
 /**
  * This method replaces plain text Types within the Markdown content into Markdown links
  * that link to the actual relevant reference for such type (either internal or external link)
@@ -150,32 +196,8 @@ export const transformTypeToReferenceLink = (type, record) => {
     return '';
   };
 
-  const { pieces: outerPieces, separator } = splitByOuterSeparator(typeInput);
-
-  const typePieces = outerPieces.map(piece => {
-    // This is the content to render as the text of the Markdown link
-    const trimmedPiece = piece.trim();
-
-    // 1. Attempt to format as a basic Generic type first
-    const genericMarkdown = formatBasicGeneric(trimmedPiece, transformType);
-    if (genericMarkdown) {
-      return genericMarkdown;
-    }
-
-    // 2. Fallback to the logic for plain types
-    // This is what we will compare against the API types mappings
-    // The ReGeX below is used to remove `[]` from the end of the type
-    const result = transformType(trimmedPiece.replace(/\[\]$/, ''));
-
-    // If we have a valid result and the piece is not empty, we return the Markdown link
-    if (trimmedPiece.length && result.length) {
-      return `[\`<${trimmedPiece}>\`](${result})`;
-    }
-  });
-
-  // Filter out pieces that we failed to map and then join the valid ones
-  // using the same separator that appeared in the original type string
-  const markdownLinks = typePieces.filter(Boolean).join(separator);
+  // Kick off the recursive parser on the cleaned input
+  const markdownLinks = parseAdvancedType(typeInput, transformType);
 
   // Return the replaced links or the original content if they all failed to be replaced
   // Note that if some failed to get replaced, only the valid ones will be returned

--- a/src/generators/metadata/utils/transformers.mjs
+++ b/src/generators/metadata/utils/transformers.mjs
@@ -41,7 +41,7 @@ const splitByOuterSeparator = (str, separator) => {
     // Track depth using brackets and parentheses
     if (char === '<' || char === '(') {
       depth++;
-    } else if (char === '>' || char === ')') {
+    } else if ((char === '>' && str[i - 1] !== '=') || char === ')') {
       depth--;
     }
 

--- a/src/generators/metadata/utils/transformers.mjs
+++ b/src/generators/metadata/utils/transformers.mjs
@@ -31,7 +31,10 @@ export const transformUnixManualToLink = (
 export const transformTypeToReferenceLink = (type, record) => {
   // Removes the wrapping curly braces that wrap the type references
   // We keep the angle brackets `<>` intact here to parse Generics later
-  const typeInput = type.replace(/[{}]/g, '');
+  const typeInput = type
+    .trim()
+    .replace(/^\{(.*)\}$/, '$1')
+    .trim();
 
   /**
    * Handles the mapping (if there's a match) of the input text

--- a/src/generators/metadata/utils/transformers.mjs
+++ b/src/generators/metadata/utils/transformers.mjs
@@ -26,10 +26,6 @@ export const transformUnixManualToLink = (
  * @param {string} separator The separator to split by (e.g., '|', '&', ',', '=>')
  * @returns {string[]} The split pieces
  */
-
-/**
- *
- */
 const splitByOuterSeparator = (str, separator) => {
   const pieces = [];
   let current = '';

--- a/src/generators/metadata/utils/typeParser.mjs
+++ b/src/generators/metadata/utils/typeParser.mjs
@@ -41,15 +41,70 @@ const splitByOuterSeparator = (str, separator) => {
   return pieces;
 };
 /**
+ * Safely removes outer parentheses from a type string if they wrap the entire string.
+ * This prevents "depth blindness" in the parser by unwrapping types like `(string | number)`
+ * into `string | number`, while safely ignoring disconnected groups like `(A) | (B)`.
+ *
+ * @param {string} typeString The type string to evaluate and potentially unwrap.
+ * @returns {string} The unwrapped type string, or the original string if not fully wrapped.
+ */
+export const stripOuterParentheses = typeString => {
+  let trimmed = typeString.trim();
+
+  if (trimmed.startsWith('(') && trimmed.endsWith(')')) {
+    let depth = 0;
+    let isValidWrapper = true;
+
+    // Iterate through the string, ignoring the last closing parenthesis
+    for (let i = 0; i < trimmed.length - 1; i++) {
+      if (trimmed[i] === '(') {
+        depth++;
+      } else if (trimmed[i] === ')') {
+        depth--;
+      }
+
+      // If depth hits 0 before the end, it means the parentheses don't wrap the whole string
+      if (depth === 0) {
+        isValidWrapper = false;
+        break;
+      }
+    }
+
+    if (isValidWrapper) {
+      return trimmed.slice(1, -1).trim();
+    }
+  }
+
+  return trimmed;
+};
+/**
  * Recursively parses advanced TypeScript types, including Unions, Intersections, Functions, and Nested Generics.
  * * @param {string} typeString The plain type string to evaluate
  * @param {Function} transformType The function used to resolve individual types into links
  * @returns {string|null} The formatted Markdown link(s), or null if the base type doesn't map
  */
 export const parseType = (typeString, transformType) => {
-  const trimmed = typeString.trim();
+  // Clean the string and strip unnecessary outer parentheses to prevent depth blindness (e.g., "(string | number)" -> "string | number")
+  const trimmed = stripOuterParentheses(typeString);
   if (!trimmed) {
     return null;
+  }
+
+  // Handle Functions (=>)
+  if (trimmed.includes('=>')) {
+    const parts = splitByOuterSeparator(trimmed, '=>');
+    if (parts.length > 1) {
+      const params = parts[0];
+
+      // Join the rest back together to handle higher-order functions
+      const returnType = parts.slice(1).join(' => ');
+
+      // Preserve the function signature, just link the return type for now
+      // (Mapping param types inside the signature string is complex and often unnecessary for simple docs)
+      const parsedReturn =
+        parseType(returnType, transformType) || `\`<${returnType}>\``;
+      return `${params} =&gt; ${parsedReturn}`;
+    }
   }
 
   // Handle Unions (|)
@@ -76,45 +131,39 @@ export const parseType = (typeString, transformType) => {
     }
   }
 
-  // Handle Functions (=>)
-  if (trimmed.includes('=>')) {
-    const parts = splitByOuterSeparator(trimmed, '=>');
-    if (parts.length === 2) {
-      const params = parts[0];
-      const returnType = parts[1];
+  // Handle Generics (Base<Inner, Inner>)
+  // Check if it's a generic wrapped in an array (e.g., Promise<string>[])
+  const isGenericArray = trimmed.endsWith('[]');
+  const genericTarget = isGenericArray ? trimmed.slice(0, -2).trim() : trimmed;
 
-      // Preserve the function signature, just link the return type for now
-      // (Mapping param types inside the signature string is complex and often unnecessary for simple docs)
-      const parsedReturn =
-        parseType(returnType, transformType) || `\`<${returnType}>\``;
-      return `${params} =&gt; ${parsedReturn}`;
-    }
-  }
+  if (genericTarget.includes('<') && genericTarget.endsWith('>')) {
+    const firstBracketIndex = genericTarget.indexOf('<');
+    const baseType = genericTarget.slice(0, firstBracketIndex).trim();
+    const innerType = genericTarget.slice(firstBracketIndex + 1, -1).trim();
 
-  // 3. Handle Generics (Base<Inner, Inner>)
-  if (trimmed.includes('<') && trimmed.endsWith('>')) {
-    const firstBracketIndex = trimmed.indexOf('<');
-    const baseType = trimmed.slice(0, firstBracketIndex).trim();
-    const innerType = trimmed.slice(firstBracketIndex + 1, -1).trim();
+    const cleanBaseType = baseType.replace(/\[\]$/, ''); // Just in case of Base[]<Inner>
+    const baseResult = transformType(cleanBaseType);
 
-    const baseResult = transformType(baseType.replace(/\[\]$/, ''));
     const baseFormatted = baseResult
-      ? `[\`<${baseType}>\`](${baseResult})`
-      : `\`<${baseType}>\``;
+      ? `[\`<${cleanBaseType}>\`](${baseResult})`
+      : `\`<${cleanBaseType}>\``;
 
-    // Split arguments safely by comma
     const innerArgs = splitByOuterSeparator(innerType, ',');
     const innerFormatted = innerArgs
       .map(arg => parseType(arg, transformType) || `\`<${arg}>\``)
       .join(', ');
 
-    return `${baseFormatted}&lt;${innerFormatted}&gt;`;
+    return `${baseFormatted}&lt;${innerFormatted}&gt;${isGenericArray ? '[]' : ''}`;
   }
 
   // Base Case: Plain Type (e.g., string, Buffer, Function)
-  const result = transformType(trimmed.replace(/\[\]$/, ''));
-  if (trimmed.length && result) {
-    return `[\`<${trimmed}>\`](${result})`;
+  // Preserve array notation for base types
+  const isArray = trimmed.endsWith('[]');
+  const cleanType = trimmed.replace(/\[\]$/, '');
+
+  const result = transformType(cleanType);
+  if (cleanType.length && result) {
+    return `[\`<${cleanType}>\`](${result})${isArray ? '[]' : ''}`;
   }
 
   return null;

--- a/src/generators/metadata/utils/typeParser.mjs
+++ b/src/generators/metadata/utils/typeParser.mjs
@@ -1,5 +1,9 @@
+const openParentheses = ['<', '(', '{', '['];
+const closeParentheses = ['>', ')', '}', ']'];
+
 /**
- * Safely splits a string by a given set of separators at depth 0 (ignoring those inside < > or ( )).
+ * Safely splits a string by a given set of separators at depth 0
+ * (ignoring those inside < >, ( ), { }, or [ ]).
  *
  * @param {string} str The string to split
  * @param {string} separator The separator to split by (e.g., '|', '&', ',', '=>')
@@ -13,11 +17,14 @@ const splitByOuterSeparator = (str, separator) => {
   for (let i = 0; i < str.length; i++) {
     const char = str[i];
 
-    // Track depth using brackets and parentheses
-    if (char === '<' || char === '(') {
+    // Track depth using the global arrays
+    if (openParentheses.includes(char)) {
       depth++;
-    } else if ((char === '>' && str[i - 1] !== '=') || char === ')') {
-      depth--;
+    } else if (closeParentheses.includes(char)) {
+      // Small exception: don't decrease depth for the '>' in '=>'
+      if (!(char === '>' && str[i - 1] === '=')) {
+        depth--;
+      }
     }
 
     // Check for multi-character separators like '=>'
@@ -40,9 +47,10 @@ const splitByOuterSeparator = (str, separator) => {
   pieces.push(current.trim());
   return pieces;
 };
+
 /**
  * Safely removes outer parentheses from a type string if they wrap the entire string.
- * This prevents "depth blindness" in the parser by unwrapping types like `(string | number)`
+ * This prevents "depth blindness" in the parser by recursively unwrapping types like `(((string | number)))`
  * into `string | number`, while safely ignoring disconnected groups like `(A) | (B)`.
  *
  * @param {string} typeString The type string to evaluate and potentially unwrap.
@@ -51,16 +59,21 @@ const splitByOuterSeparator = (str, separator) => {
 const stripOuterParentheses = typeString => {
   let trimmed = typeString.trim();
 
+  // Only attempt to unwrap if it's enclosed in standard grouping parentheses
   if (trimmed.startsWith('(') && trimmed.endsWith(')')) {
     let depth = 0;
     let isValidWrapper = true;
 
     // Iterate through the string, ignoring the last closing parenthesis
     for (let i = 0; i < trimmed.length - 1; i++) {
-      if (trimmed[i] === '(') {
+      const char = trimmed[i];
+
+      if (openParentheses.includes(char)) {
         depth++;
-      } else if (trimmed[i] === ')') {
-        depth--;
+      } else if (closeParentheses.includes(char)) {
+        if (!(char === '>' && trimmed[i - 1] === '=')) {
+          depth--;
+        }
       }
 
       // If depth hits 0 before the end, it means the parentheses don't wrap the whole string
@@ -71,12 +84,80 @@ const stripOuterParentheses = typeString => {
     }
 
     if (isValidWrapper) {
-      return trimmed.slice(1, -1).trim();
+      const unwrapped = trimmed.slice(1, -1).trim();
+      // Keep stripping if there are multiple redundant layers
+      return stripOuterParentheses(unwrapped);
     }
   }
 
   return trimmed;
 };
+
+/**
+ * Parses the left side of an arrow function.
+ * @param {string} signature The left side of the arrow function
+ * @param {Function} transformType The resolver function
+ * @returns {string} The parsed signature with markdown links
+ */
+const parseFunctionSignature = (signature, transformType) => {
+  let trimmed = signature.trim();
+
+  // Safety fallback
+  if (!trimmed.endsWith(')')) {
+    return signature;
+  }
+
+  let depth = 0;
+  let openParenIndex = -1;
+
+  // Reverse walk to isolate parameters from prefix
+  for (let i = trimmed.length - 1; i >= 0; i--) {
+    const char = trimmed[i];
+
+    // Explicitly targeting normal parentheses for the argument wrapper
+    if (char === ')') {
+      depth++;
+    } else if (char === '(') {
+      depth--;
+    }
+
+    if (depth === 0) {
+      openParenIndex = i;
+      break;
+    }
+  }
+
+  if (openParenIndex === -1) {
+    return signature;
+  }
+
+  const prefix = trimmed.slice(0, openParenIndex);
+  const paramsString = trimmed.slice(openParenIndex + 1, -1);
+
+  if (!paramsString.trim()) {
+    return `${prefix}()`;
+  }
+
+  const args = splitByOuterSeparator(paramsString, ',');
+
+  const parsedArgs = args.map(arg => {
+    const colonParts = splitByOuterSeparator(arg, ':');
+
+    if (colonParts.length > 1) {
+      const paramName = colonParts[0];
+      const paramType = colonParts.slice(1).join(':');
+
+      const parsedType =
+        parseType(paramType, transformType) || `\`<${paramType}>\``;
+      return `${paramName}: ${parsedType}`;
+    }
+
+    return parseType(arg, transformType) || arg;
+  });
+
+  return `${prefix}(${parsedArgs.join(', ')})`;
+};
+
 /**
  * Recursively parses advanced TypeScript types, including Unions, Intersections, Functions, and Nested Generics.
  * * @param {string} typeString The plain type string to evaluate
@@ -84,7 +165,7 @@ const stripOuterParentheses = typeString => {
  * @returns {string|null} The formatted Markdown link(s), or null if the base type doesn't map
  */
 export const parseType = (typeString, transformType) => {
-  // Clean the string and strip unnecessary outer parentheses to prevent depth blindness (e.g., "(string | number)" -> "string | number")
+  // Clean the string and strip unnecessary outer parentheses to prevent depth blindness
   const trimmed = stripOuterParentheses(typeString);
   if (!trimmed) {
     return null;
@@ -118,16 +199,14 @@ export const parseType = (typeString, transformType) => {
   if (trimmed.includes('=>')) {
     const parts = splitByOuterSeparator(trimmed, '=>');
     if (parts.length > 1) {
-      const params = parts[0];
-
-      // Join the rest back together to handle higher-order functions
+      const signature = parts[0];
       const returnType = parts.slice(1).join(' => ');
 
-      // Preserve the function signature, just link the return type for now
-      // (Mapping param types inside the signature string is complex and often unnecessary for simple docs)
+      const parsedSignature = parseFunctionSignature(signature, transformType);
+
       const parsedReturn =
         parseType(returnType, transformType) || `\`<${returnType}>\``;
-      return `${params} =&gt; ${parsedReturn}`;
+      return `${parsedSignature} =&gt; ${parsedReturn}`;
     }
   }
 

--- a/src/generators/metadata/utils/typeParser.mjs
+++ b/src/generators/metadata/utils/typeParser.mjs
@@ -90,23 +90,6 @@ export const parseType = (typeString, transformType) => {
     return null;
   }
 
-  // Handle Functions (=>)
-  if (trimmed.includes('=>')) {
-    const parts = splitByOuterSeparator(trimmed, '=>');
-    if (parts.length > 1) {
-      const params = parts[0];
-
-      // Join the rest back together to handle higher-order functions
-      const returnType = parts.slice(1).join(' => ');
-
-      // Preserve the function signature, just link the return type for now
-      // (Mapping param types inside the signature string is complex and often unnecessary for simple docs)
-      const parsedReturn =
-        parseType(returnType, transformType) || `\`<${returnType}>\``;
-      return `${params} =&gt; ${parsedReturn}`;
-    }
-  }
-
   // Handle Unions (|)
   if (trimmed.includes('|')) {
     const parts = splitByOuterSeparator(trimmed, '|');
@@ -128,6 +111,23 @@ export const parseType = (typeString, transformType) => {
         p => parseType(p, transformType) || `\`<${p}>\``
       );
       return resolvedParts.join(' & ');
+    }
+  }
+
+  // Handle Functions (=>)
+  if (trimmed.includes('=>')) {
+    const parts = splitByOuterSeparator(trimmed, '=>');
+    if (parts.length > 1) {
+      const params = parts[0];
+
+      // Join the rest back together to handle higher-order functions
+      const returnType = parts.slice(1).join(' => ');
+
+      // Preserve the function signature, just link the return type for now
+      // (Mapping param types inside the signature string is complex and often unnecessary for simple docs)
+      const parsedReturn =
+        parseType(returnType, transformType) || `\`<${returnType}>\``;
+      return `${params} =&gt; ${parsedReturn}`;
     }
   }
 

--- a/src/generators/metadata/utils/typeParser.mjs
+++ b/src/generators/metadata/utils/typeParser.mjs
@@ -48,7 +48,7 @@ const splitByOuterSeparator = (str, separator) => {
  * @param {string} typeString The type string to evaluate and potentially unwrap.
  * @returns {string} The unwrapped type string, or the original string if not fully wrapped.
  */
-export const stripOuterParentheses = typeString => {
+const stripOuterParentheses = typeString => {
   let trimmed = typeString.trim();
 
   if (trimmed.startsWith('(') && trimmed.endsWith(')')) {

--- a/src/generators/metadata/utils/typeParser.mjs
+++ b/src/generators/metadata/utils/typeParser.mjs
@@ -1,0 +1,121 @@
+/**
+ * Safely splits a string by a given set of separators at depth 0 (ignoring those inside < > or ( )).
+ *
+ * @param {string} str The string to split
+ * @param {string} separator The separator to split by (e.g., '|', '&', ',', '=>')
+ * @returns {string[]} The split pieces
+ */
+const splitByOuterSeparator = (str, separator) => {
+  const pieces = [];
+  let current = '';
+  let depth = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    // Track depth using brackets and parentheses
+    if (char === '<' || char === '(') {
+      depth++;
+    } else if ((char === '>' && str[i - 1] !== '=') || char === ')') {
+      depth--;
+    }
+
+    // Check for multi-character separators like '=>'
+    const isArrow = separator === '=>' && char === '=' && str[i + 1] === '>';
+    // Check for single-character separators
+    const isCharSeparator = separator === char;
+
+    if (depth === 0 && (isCharSeparator || isArrow)) {
+      pieces.push(current.trim());
+      current = '';
+      if (isArrow) {
+        i++;
+      } // skip the '>' part of '=>'
+      continue;
+    }
+
+    current += char;
+  }
+
+  pieces.push(current.trim());
+  return pieces;
+};
+/**
+ * Recursively parses advanced TypeScript types, including Unions, Intersections, Functions, and Nested Generics.
+ * * @param {string} typeString The plain type string to evaluate
+ * @param {Function} transformType The function used to resolve individual types into links
+ * @returns {string|null} The formatted Markdown link(s), or null if the base type doesn't map
+ */
+export const parseType = (typeString, transformType) => {
+  const trimmed = typeString.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  // Handle Unions (|)
+  if (trimmed.includes('|')) {
+    const parts = splitByOuterSeparator(trimmed, '|');
+    if (parts.length > 1) {
+      // Re-evaluate each part recursively and join with ' | '
+      const resolvedParts = parts.map(
+        p => parseType(p, transformType) || `\`<${p}>\``
+      );
+      return resolvedParts.join(' | ');
+    }
+  }
+
+  // Handle Intersections (&)
+  if (trimmed.includes('&')) {
+    const parts = splitByOuterSeparator(trimmed, '&');
+    if (parts.length > 1) {
+      // Re-evaluate each part recursively and join with ' & '
+      const resolvedParts = parts.map(
+        p => parseType(p, transformType) || `\`<${p}>\``
+      );
+      return resolvedParts.join(' & ');
+    }
+  }
+
+  // Handle Functions (=>)
+  if (trimmed.includes('=>')) {
+    const parts = splitByOuterSeparator(trimmed, '=>');
+    if (parts.length === 2) {
+      const params = parts[0];
+      const returnType = parts[1];
+
+      // Preserve the function signature, just link the return type for now
+      // (Mapping param types inside the signature string is complex and often unnecessary for simple docs)
+      const parsedReturn =
+        parseType(returnType, transformType) || `\`<${returnType}>\``;
+      return `${params} =&gt; ${parsedReturn}`;
+    }
+  }
+
+  // 3. Handle Generics (Base<Inner, Inner>)
+  if (trimmed.includes('<') && trimmed.endsWith('>')) {
+    const firstBracketIndex = trimmed.indexOf('<');
+    const baseType = trimmed.slice(0, firstBracketIndex).trim();
+    const innerType = trimmed.slice(firstBracketIndex + 1, -1).trim();
+
+    const baseResult = transformType(baseType.replace(/\[\]$/, ''));
+    const baseFormatted = baseResult
+      ? `[\`<${baseType}>\`](${baseResult})`
+      : `\`<${baseType}>\``;
+
+    // Split arguments safely by comma
+    const innerArgs = splitByOuterSeparator(innerType, ',');
+    const innerFormatted = innerArgs
+      .map(arg => parseType(arg, transformType) || `\`<${arg}>\``)
+      .join(', ');
+
+    return `${baseFormatted}&lt;${innerFormatted}&gt;`;
+  }
+
+  // Base Case: Plain Type (e.g., string, Buffer, Function)
+  const result = transformType(trimmed.replace(/\[\]$/, ''));
+  if (trimmed.length && result) {
+    return `[\`<${trimmed}>\`](${result})`;
+  }
+
+  return null;
+};

--- a/src/generators/metadata/utils/typeParser.mjs
+++ b/src/generators/metadata/utils/typeParser.mjs
@@ -1,157 +1,177 @@
-const openParentheses = ['<', '(', '{', '['];
-const closeParentheses = ['>', ')', '}', ']'];
+import { TYPE_OPENERS, TYPE_CLOSERS } from '../constants.mjs';
+
+/** True when the `>` at `i` is the tail of `=>` and shouldn't pop depth. */
+const isArrowTail = (str, i) => str[i] === '>' && str[i - 1] === '=';
 
 /**
- * Safely splits a string by a given set of separators at depth 0
- * (ignoring those inside < >, ( ), { }, or [ ]).
- *
- * @param {string} str The string to split
- * @param {string} separator The separator to split by (e.g., '|', '&', ',', '=>')
- * @returns {string[]} The split pieces
+ * Walks `str` once, invoking `onToken(i, char)` for each character that
+ * sits at depth 0. `onToken` may return:
+ * - a number: advance the cursor by that many extra positions
+ * - `true`: stop iteration altogether
  */
-const splitByOuterSeparator = (str, separator) => {
-  const pieces = [];
-  let current = '';
+const walkAtDepthZero = (str, onToken) => {
   let depth = 0;
-
   for (let i = 0; i < str.length; i++) {
     const char = str[i];
-
-    // Track depth using the global arrays
-    if (openParentheses.includes(char)) {
+    if (TYPE_OPENERS.has(char)) {
       depth++;
-    } else if (closeParentheses.includes(char)) {
-      // Small exception: don't decrease depth for the '>' in '=>'
-      if (!(char === '>' && str[i - 1] === '=')) {
-        depth--;
-      }
-    }
-
-    // Check for multi-character separators like '=>'
-    const isArrow = separator === '=>' && char === '=' && str[i + 1] === '>';
-    // Check for single-character separators
-    const isCharSeparator = separator === char;
-
-    if (depth === 0 && (isCharSeparator || isArrow)) {
-      pieces.push(current.trim());
-      current = '';
-      if (isArrow) {
-        i++;
-      } // skip the '>' part of '=>'
-      continue;
-    }
-
-    current += char;
-  }
-
-  pieces.push(current.trim());
-  return pieces;
-};
-
-/**
- * Safely removes outer parentheses from a type string if they wrap the entire string.
- * This prevents "depth blindness" in the parser by recursively unwrapping types like `(((string | number)))`
- * into `string | number`, while safely ignoring disconnected groups like `(A) | (B)`.
- *
- * @param {string} typeString The type string to evaluate and potentially unwrap.
- * @returns {string} The unwrapped type string, or the original string if not fully wrapped.
- */
-const stripOuterParentheses = typeString => {
-  let trimmed = typeString.trim();
-
-  // Only attempt to unwrap if it's enclosed in standard grouping parentheses
-  if (trimmed.startsWith('(') && trimmed.endsWith(')')) {
-    let depth = 0;
-    let isValidWrapper = true;
-
-    // Iterate through the string, ignoring the last closing parenthesis
-    for (let i = 0; i < trimmed.length - 1; i++) {
-      const char = trimmed[i];
-
-      if (openParentheses.includes(char)) {
-        depth++;
-      } else if (closeParentheses.includes(char)) {
-        if (!(char === '>' && trimmed[i - 1] === '=')) {
-          depth--;
-        }
-      }
-
-      // If depth hits 0 before the end, it means the parentheses don't wrap the whole string
-      if (depth === 0) {
-        isValidWrapper = false;
-        break;
-      }
-    }
-
-    if (isValidWrapper) {
-      const unwrapped = trimmed.slice(1, -1).trim();
-      // Keep stripping if there are multiple redundant layers
-      return stripOuterParentheses(unwrapped);
-    }
-  }
-
-  return trimmed;
-};
-
-/**
- * Parses the left side of an arrow function.
- * @param {string} signature The left side of the arrow function
- * @param {Function} transformType The resolver function
- * @returns {string} The parsed signature with markdown links
- */
-const parseFunctionSignature = (signature, transformType) => {
-  let trimmed = signature.trim();
-
-  // Safety fallback
-  if (!trimmed.endsWith(')')) {
-    return signature;
-  }
-
-  let depth = 0;
-  let openParenIndex = -1;
-
-  // Reverse walk to isolate parameters from prefix
-  for (let i = trimmed.length - 1; i >= 0; i--) {
-    const char = trimmed[i];
-
-    // Explicitly targeting normal parentheses for the argument wrapper
-    if (char === ')') {
-      depth++;
-    } else if (char === '(') {
+    } else if (TYPE_CLOSERS.has(char) && !isArrowTail(str, i)) {
       depth--;
     }
 
     if (depth === 0) {
-      openParenIndex = i;
-      break;
+      const skip = onToken(i, char);
+      if (skip === true) {
+        return;
+      }
+      if (typeof skip === 'number') {
+        i += skip;
+      }
     }
   }
+};
 
-  if (openParenIndex === -1) {
+/** Format a known type as a Markdown link, or as a bare code span. */
+const formatType = (name, transformType) => {
+  const url = transformType(name);
+  return url ? `[\`<${name}>\`](${url})` : `\`<${name}>\``;
+};
+
+/** Resolve a sub-expression recursively, falling back to a code span. */
+const resolveOr = (part, transformType) =>
+  parseType(part, transformType) || `\`<${part.trim()}>\``;
+
+/**
+ * Splits `str` by `separator` at depth 0. `separator` is a single
+ * character or the two-char string '=>'.
+ */
+const splitByOuterSeparator = (str, separator) => {
+  const isArrow = separator === '=>';
+  const pieces = [];
+  let start = 0;
+
+  walkAtDepthZero(str, (i, char) => {
+    const matches = isArrow
+      ? char === '=' && str[i + 1] === '>'
+      : char === separator;
+    if (!matches) {
+      return;
+    }
+    pieces.push(str.slice(start, i).trim());
+    start = i + (isArrow ? 2 : 1);
+    if (isArrow) {
+      return 1;
+    } // skip the '>'
+  });
+
+  pieces.push(str.slice(start).trim());
+  return pieces;
+};
+
+/**
+ * Strips redundant outer parens like `((A | B))` → `A | B`, while
+ * leaving `(A) | (B)` alone.
+ */
+const stripOuterParentheses = typeString => {
+  let s = typeString.trim();
+  while (s.length >= 2 && s.startsWith('(') && s.endsWith(')')) {
+    // The outer `(` matches the outer `)` if depth doesn't hit 0
+    // anywhere before the final character.
+    let wrapsWhole = true;
+    walkAtDepthZero(s.slice(0, -1), i => {
+      if (i > 0) {
+        wrapsWhole = false;
+        return true; // stop early
+      }
+    });
+    if (!wrapsWhole) {
+      break;
+    }
+    s = s.slice(1, -1).trim();
+  }
+  return s;
+};
+
+/**
+ * Finds the lowest-precedence top-level operator: `=>` beats `|` beats
+ * `&`.
+ */
+const findTopLevelOperator = str => {
+  let arrowIdx = -1;
+  let unionIdx = -1;
+  let intersectIdx = -1;
+
+  walkAtDepthZero(str, (i, char) => {
+    if (char === '=' && str[i + 1] === '>') {
+      if (arrowIdx === -1) {
+        arrowIdx = i;
+      }
+      return 1; // skip '>'
+    }
+    if (char === '|' && unionIdx === -1) {
+      unionIdx = i;
+    } else if (char === '&' && intersectIdx === -1) {
+      intersectIdx = i;
+    }
+  });
+
+  if (arrowIdx !== -1) {
+    return { op: '=>', index: arrowIdx, width: 2 };
+  }
+
+  if (unionIdx !== -1) {
+    return { op: '|', index: unionIdx, width: 1 };
+  }
+
+  if (intersectIdx !== -1) {
+    return { op: '&', index: intersectIdx, width: 1 };
+  }
+
+  return null;
+};
+
+/**
+ * Parses the left side of an arrow function (e.g. `(a: string, b: number)`
+ * or `<T>(x: T)`). Locates the parameter list as the last `(` that opens
+ * at depth 0.
+ */
+const parseFunctionSignature = (signature, transformType) => {
+  const trimmed = signature.trim();
+  if (!trimmed.endsWith(')')) {
     return signature;
   }
 
-  const prefix = trimmed.slice(0, openParenIndex);
-  const paramsString = trimmed.slice(openParenIndex + 1, -1);
+  // Find the `(` that opens the outermost group ending at the final `)`.
+  let depth = 0;
+  let openIdx = -1;
+  for (let i = 0; i < trimmed.length; i++) {
+    const char = trimmed[i];
+    if (depth === 0 && char === '(') {
+      openIdx = i;
+    }
+    if (TYPE_OPENERS.has(char)) {
+      depth++;
+    } else if (TYPE_CLOSERS.has(char) && !isArrowTail(trimmed, i)) {
+      depth--;
+    }
+  }
+  if (openIdx === -1) {
+    return signature;
+  }
 
+  const prefix = trimmed.slice(0, openIdx);
+  const paramsString = trimmed.slice(openIdx + 1, -1);
   if (!paramsString.trim()) {
     return `${prefix}()`;
   }
 
-  const args = splitByOuterSeparator(paramsString, ',');
-
-  const parsedArgs = args.map(arg => {
+  const parsedArgs = splitByOuterSeparator(paramsString, ',').map(arg => {
     const colonParts = splitByOuterSeparator(arg, ':');
-
     if (colonParts.length > 1) {
       const paramName = colonParts[0];
       const paramType = colonParts.slice(1).join(':');
-
-      const parsedType =
-        parseType(paramType, transformType) || `\`<${paramType}>\``;
-      return `${paramName}: ${parsedType}`;
+      return `${paramName}: ${resolveOr(paramType, transformType)}`;
     }
-
     return parseType(arg, transformType) || arg;
   });
 
@@ -159,91 +179,58 @@ const parseFunctionSignature = (signature, transformType) => {
 };
 
 /**
- * Recursively parses advanced TypeScript types, including Unions, Intersections, Functions, and Nested Generics.
- * * @param {string} typeString The plain type string to evaluate
- * @param {Function} transformType The function used to resolve individual types into links
- * @returns {string|null} The formatted Markdown link(s), or null if the base type doesn't map
+ * Recursively parses TypeScript types into Markdown links.
+ *
+ * @param {string} typeString The type string to evaluate.
+ * @param {(name: string) => string | null | undefined} transformType Resolves a bare type name to a URL, or returns falsy.
+ * @returns {string | null} Markdown for the type, or null when the base type doesn't resolve.
  */
 export const parseType = (typeString, transformType) => {
-  // Clean the string and strip unnecessary outer parentheses to prevent depth blindness
   const trimmed = stripOuterParentheses(typeString);
   if (!trimmed) {
     return null;
   }
 
-  // Handle Unions (|)
-  if (trimmed.includes('|')) {
-    const parts = splitByOuterSeparator(trimmed, '|');
-    if (parts.length > 1) {
-      // Re-evaluate each part recursively and join with ' | '
-      const resolvedParts = parts.map(
-        p => parseType(p, transformType) || `\`<${p}>\``
-      );
-      return resolvedParts.join(' | ');
+  const op = findTopLevelOperator(trimmed);
+  if (op) {
+    if (op.op === '=>') {
+      const left = trimmed.slice(0, op.index).trim();
+      const right = trimmed.slice(op.index + op.width).trim();
+      const sig = parseFunctionSignature(left, transformType);
+      return `${sig} =&gt; ${resolveOr(right, transformType)}`;
     }
+
+    // Union / intersection
+    const parts = splitByOuterSeparator(trimmed, op.op);
+    const joiner = op.op === '|' ? ' | ' : ' & ';
+    return parts.map(p => resolveOr(p, transformType)).join(joiner);
   }
 
-  // Handle Intersections (&)
-  if (trimmed.includes('&')) {
-    const parts = splitByOuterSeparator(trimmed, '&');
-    if (parts.length > 1) {
-      // Re-evaluate each part recursively and join with ' & '
-      const resolvedParts = parts.map(
-        p => parseType(p, transformType) || `\`<${p}>\``
-      );
-      return resolvedParts.join(' & ');
-    }
-  }
-
-  // Handle Functions (=>)
-  if (trimmed.includes('=>')) {
-    const parts = splitByOuterSeparator(trimmed, '=>');
-    if (parts.length > 1) {
-      const signature = parts[0];
-      const returnType = parts.slice(1).join(' => ');
-
-      const parsedSignature = parseFunctionSignature(signature, transformType);
-
-      const parsedReturn =
-        parseType(returnType, transformType) || `\`<${returnType}>\``;
-      return `${parsedSignature} =&gt; ${parsedReturn}`;
-    }
-  }
-
-  // Handle Generics (Base<Inner, Inner>)
-  // Check if it's a generic wrapped in an array (e.g., Promise<string>[])
-  const isGenericArray = trimmed.endsWith('[]');
-  const genericTarget = isGenericArray ? trimmed.slice(0, -2).trim() : trimmed;
-
-  if (genericTarget.includes('<') && genericTarget.endsWith('>')) {
-    const firstBracketIndex = genericTarget.indexOf('<');
-    const baseType = genericTarget.slice(0, firstBracketIndex).trim();
-    const innerType = genericTarget.slice(firstBracketIndex + 1, -1).trim();
-
-    const cleanBaseType = baseType.replace(/\[\]$/, ''); // Just in case of Base[]<Inner>
-    const baseResult = transformType(cleanBaseType);
-
-    const baseFormatted = baseResult
-      ? `[\`<${cleanBaseType}>\`](${baseResult})`
-      : `\`<${cleanBaseType}>\``;
-
-    const innerArgs = splitByOuterSeparator(innerType, ',');
-    const innerFormatted = innerArgs
-      .map(arg => parseType(arg, transformType) || `\`<${arg}>\``)
-      .join(', ');
-
-    return `${baseFormatted}&lt;${innerFormatted}&gt;${isGenericArray ? '[]' : ''}`;
-  }
-
-  // Base Case: Plain Type (e.g., string, Buffer, Function)
-  // Preserve array notation for base types
+  // Strip a trailing `[]` for now; reapply on the way out.
   const isArray = trimmed.endsWith('[]');
-  const cleanType = trimmed.replace(/\[\]$/, '');
+  const core = isArray ? trimmed.slice(0, -2).trim() : trimmed;
+  const arrayTail = isArray ? '[]' : '';
 
-  const result = transformType(cleanType);
-  if (cleanType.length && result) {
-    return `[\`<${cleanType}>\`](${result})${isArray ? '[]' : ''}`;
+  // Generic: `Base<...>`.
+  const ltIdx = core.indexOf('<');
+  if (ltIdx !== -1 && core.endsWith('>')) {
+    const baseType = core.slice(0, ltIdx).trim();
+    const innerType = core.slice(ltIdx + 1, -1).trim();
+    const inner = splitByOuterSeparator(innerType, ',')
+      .map(arg => resolveOr(arg, transformType))
+      .join(', ');
+    return `${formatType(baseType, transformType)}&lt;${inner}&gt;${arrayTail}`;
   }
 
-  return null;
+  // Plain base type.
+  if (!core.length) {
+    return null;
+  }
+
+  const url = transformType(core);
+  if (!url) {
+    return null;
+  }
+
+  return `[\`<${core}>\`](${url})${arrayTail}`;
 };


### PR DESCRIPTION
## Description

This PR uses the Recursive approach instead of using Regex that just covered the basic generic and can't handle:
- **Nested Generics** `Transformer<T, Awaitable<U>>`
- **Function Signature** `(str: MyType) => Promise<T>`
-  **Complex Union and Intersection** `string & number | boolean`
- **Depth** 

The new implementation uses a top-down Recursive approach, breaking down types layer by layer starting from the weakest operators to the strongest.

## Validation

- Added comprehensive test cases in `transformers.test.mjs`
- Run `node --run test` and verified that all test cases (old and new) passed successfully.

## Related Issues

This PR acts as an extension to #666. While #666 solved the basic mapping, this implementation introduces a recursive parser to handle more complex nested types.

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `node --run test` and all tests passed.
- [X] I have check code formatting with `node --run format` & `node --run lint`.
- [X] I've covered new added functionality with unit tests if necessary.
