### PR TITLE
docs(web): add description for #theme/Footer and #theme/Metabar

### DIFF
--- a/src/generators/web/README.md
+++ b/src/generators/web/README.md
@@ -20,12 +20,14 @@ The `web` generator accepts the following configuration options:
 
 #### Default `imports`
 
-| Alias               | Default                                      | Description                                  |
-| ------------------- | -------------------------------------------- | -------------------------------------------- |
-| `#theme/Logo`       | `@node-core/ui-components/Common/NodejsLogo` | Logo rendered inside the navigation bar      |
-| `#theme/Navigation` | Built-in `NavBar` component                  | Top navigation bar                           |
-| `#theme/Sidebar`    | Built-in `SideBar` component                 | Sidebar with version selector and page links |
-| `#theme/Layout`     | Built-in `Layout` component                  | Outermost wrapper around the full page       |
+| Alias               | Default                                      | Description                                         |
+| ------------------- | -------------------------------------------- | --------------------------------------------------- |
+| `#theme/Logo`       | `@node-core/ui-components/Common/NodejsLogo` | Logo rendered inside the navigation bar             |
+| `#theme/Navigation` | Built-in `NavBar` component                  | Top navigation bar                                  |
+| `#theme/Sidebar`    | Built-in `SideBar` component                 | Sidebar with version selector and page links        |
+| `#theme/Metabar`    | Built-in `MetaBar` component                 | Metadata bar displayed alongside page content       |
+| `#theme/Footer`     | Built-in `NoOp` component (renders nothing)  | Optional footer rendered at the bottom of each page |
+| `#theme/Layout`     | Built-in `Layout` component                  | Outermost wrapper around the full page              |
 
 Override any alias in your config file to swap in a custom component:
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
The web generator supports 6 overridable #theme/* aliases, but the README only documents 4 of them. This PR adds the missing #theme/Metabar and #theme/Footer entries to the default imports table, introduced in #677.

<!-- Write a brief description of the changes introduced by this PR -->

## Validation
No functional changes

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues
Related to #677

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
