### PR TITLE
fix: resolve flash of unstyled content in dark mode

### DIFF
--- a/src/generators/web/template.html
+++ b/src/generators/web/template.html
@@ -19,7 +19,7 @@
     href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=Open+Sans:ital,wght@0,300..800;1,300..800" />
 
   <!-- Apply theme before paint to avoid Flash of Unstyled Content -->
-  <script>document.documentElement.setAttribute("data-theme", document.documentElement.style.colorScheme = localStorage.getItem("theme") || (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"));</script>
+  <script>${themeScript}</script>
   <script type="importmap">${importMap}</script>
   <script type="speculationrules">${speculationRules}</script>
 </head>

--- a/src/generators/web/ui/theme-script.mjs
+++ b/src/generators/web/ui/theme-script.mjs
@@ -1,0 +1,26 @@
+'use strict';
+
+/**
+ * This script is designed to be inlined in the <head> of the HTML template.
+ * It must execute BEFORE the body renders to prevent a Flash of Unstyled Content (FOUC).
+ */
+function initializeTheme() {
+  var THEME_STORAGE_KEY = 'theme';
+  var THEME_DATA_ATTRIBUTE = 'data-theme';
+  var DARK_QUERY = '(prefers-color-scheme: dark)';
+
+  var savedUserPreference = localStorage.getItem(THEME_STORAGE_KEY);
+  var systemSupportsDarkMode = window.matchMedia(DARK_QUERY).matches;
+
+  var shouldApplyDark =
+    savedUserPreference === 'dark' ||
+    (savedUserPreference === 'system' && systemSupportsDarkMode) ||
+    (!savedUserPreference && systemSupportsDarkMode);
+
+  var themeToApply = shouldApplyDark ? 'dark' : 'light';
+
+  document.documentElement.setAttribute(THEME_DATA_ATTRIBUTE, themeToApply);
+  document.documentElement.style.colorScheme = themeToApply;
+}
+
+export var THEME_SCRIPT = `(${initializeTheme.toString()})();`;

--- a/src/generators/web/utils/processing.mjs
+++ b/src/generators/web/utils/processing.mjs
@@ -13,6 +13,7 @@ import getConfig from '../../../utils/configuration/index.mjs';
 import { populate } from '../../../utils/configuration/templates.mjs';
 import { minifyHTML } from '../../../utils/html-minifier.mjs';
 import { SPECULATION_RULES } from '../constants.mjs';
+import { THEME_SCRIPT } from '../ui/theme-script.mjs';
 
 /**
  * Populates a template string by evaluating it as a JavaScript template literal,
@@ -137,6 +138,7 @@ export async function processJSXEntries(entries, template) {
         importMap: clientBundle.importMap?.replaceAll('/', root) ?? '',
         entrypoint: `${data.api}.js?${randomUUID()}`,
         speculationRules: SPECULATION_RULES,
+        themeScript: THEME_SCRIPT,
         root,
         metadata: data,
         config,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
This PR resolves the FOUC  by resolving `system` to `dark` or `light` using matchMedia.
Earlier `system` was directly being applied as `set-theme = system`
<!-- Write a brief description of the changes introduced by this PR -->

## Validation
### before :
[Screencast from 2026-04-13 19-26-34.webm](https://github.com/user-attachments/assets/1b37aadd-fa15-4c04-ba70-5832d318d4b4)

### after : 
[Screencast from 2026-04-13 19-24-03.webm](https://github.com/user-attachments/assets/ba8c5424-b191-40f0-b4e2-37e590f981a9)


<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues
n/a

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
