### PR TITLE
fix: disable wasm highlighter for big endian platforms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@node-core/doc-kit",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@node-core/doc-kit",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
         "@actions/core": "^3.0.0",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@node-core/doc-kit",
   "type": "module",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nodejs/doc-kit.git"

--- a/src/utils/highlighter.mjs
+++ b/src/utils/highlighter.mjs
@@ -1,5 +1,7 @@
 'use strict';
 
+import { endianness } from 'node:os';
+
 import createHighlighter from '@node-core/rehype-shiki';
 import { h as createElement } from 'hastscript';
 import { SKIP, visit } from 'unist-util-visit';
@@ -40,7 +42,10 @@ export const highlighter = await createHighlighter({
   // riscv64 with sv39 has limited virtual memory space, where creating
   // too many (>20) wasm memory instances fails.
   // https://github.com/nodejs/node/pull/60591
-  wasm: process.arch !== 'riscv64',
+  //
+  // The wasm highlighter is currently not compatible with big endian.
+  // https://github.com/nodejs/node/pull/62512#issuecomment-4243469950
+  wasm: process.arch !== 'riscv64' && endianness() === 'LE',
 });
 
 /**


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

In PR [fix: disable wasm highlighter on riscv64](https://github.com/nodejs/doc-kit/pull/691), as an unrelated change, the wasm highlighter is re-enabled for s390x given the corresponding bug has been fixed. It later broke node.js CI in https://github.com/nodejs/node/pull/62512 because the wasm highlighter is not compatible with big endian platforms like s390x.

Thus disable the wasm highlighter for all big endian platforms until it is fixed.

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

- https://github.com/nodejs/node/pull/62512
- https://github.com/nodejs/doc-kit/pull/691

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
