### PR TITLE
fix(utils): handle raw hashes and queries in url relative() + add tests

### DIFF
--- a/src/utils/__tests__/url.test.mjs
+++ b/src/utils/__tests__/url.test.mjs
@@ -1,0 +1,44 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { relative } from '../url.mjs';
+
+describe('url util', () => {
+  describe('relative()', () => {
+    it('returns the same URL if it includes a protocol', () => {
+      assert.equal(
+        relative('https://example.com', '/foo/bar'),
+        'https://example.com'
+      );
+      assert.equal(
+        relative('http://nodejs.org', '/foo/bar'),
+        'http://nodejs.org'
+      );
+    });
+
+    it('returns the same URL if it starts with a hash fragment', () => {
+      assert.equal(relative('#fragment', '/foo/index.html'), '#fragment');
+    });
+
+    it('returns the same URL if it starts with a query string', () => {
+      assert.equal(relative('?query=true', '/foo/index.html'), '?query=true');
+    });
+
+    it('returns the relative path between two URLs', () => {
+      assert.equal(relative('/api/fs.html', '/api/crypto.html'), 'fs.html');
+      assert.equal(
+        relative('/api/fs.html#slug', '/api/fs.html'),
+        'fs.html#slug'
+      );
+      assert.equal(
+        relative('/foo/bar.html', '/baz/qux.html'),
+        '../foo/bar.html'
+      );
+      assert.equal(
+        relative('/foo/bar.html', '/foo/bar/baz.html'),
+        '../bar.html'
+      );
+      assert.equal(relative('/a/b/c.html', '/x/y/z.html'), '../../a/b/c.html');
+    });
+  });
+});

--- a/src/utils/url.mjs
+++ b/src/utils/url.mjs
@@ -9,6 +9,10 @@ export const relative = (to, from) => {
     return to;
   }
 
+  if (to.startsWith('#') || to.startsWith('?')) {
+    return to;
+  }
+
   const a = to.split('/').filter(Boolean);
   const b = from.split('/').slice(0, -1).filter(Boolean);
 


### PR DESCRIPTION
Description
This PR adds the missing unit tests for the relative utility in `src/utils/url.mjs` and patches a minor logic flaw in how it handles hashes and query strings. I included a quick short-circuit to ensure that raw fragments (like `#fragment`) stay completely intact instead of being mistakenly processed as directory paths.


**Note: This is not actively breaking the site right now because no component
currently passes a raw hash to the resolver. However, it is a dormant footgun
that could easily cause unexpected bugs if routing or navigation changes in the future.***


Validation
I ran the Node test suite locally to verify the new url.test.mjs file. The tests confirm that all URL resolution edge cases are handled perfectly and that the existing logic remains completely untouched.

Related Issues
No Related Issues.

Check List
- [x] I have read the Contributing Guidelines and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
