### PR TITLE
fix(web): add noopener and noreferrer to external source links

### DIFF
--- a/src/generators/jsx-ast/utils/buildContent.mjs
+++ b/src/generators/jsx-ast/utils/buildContent.mjs
@@ -90,6 +90,7 @@ export const createSourceLink = sourceLink => {
           {
             href: `${populate(GITHUB_BLOB_URL, config)}${sourceLink}`,
             target: '_blank',
+            rel: 'noopener noreferrer',
           },
           [
             sourceLink,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Adds rel="noopener noreferrer" to source-code links generated by the web docs pipeline when links open in a new tab (target="_blank").

The source link rendering in jsx-ast currently opens external GitHub links in a new tab but does not set a rel attribute. This change hardens link behavior by preventing opener access and aligning with standard security best practices for external links.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
I validated this by generating docs and inspecting rendered source-code links in the output HTML.

### Before
Generated source links had:

target="_blank"
no rel attribute

### After
Generated source links now have:

target="_blank"
rel="noopener noreferrer"

This preserves existing behavior (open in new tab) while adding safer link semantics.

## Related Issues
N/A

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
