### PR TITLE
fix(web): bind clipboard writeText in CodeBox copy handler

### DIFF
--- a/src/generators/web/ui/components/CodeBox.jsx
+++ b/src/generators/web/ui/components/CodeBox.jsx
@@ -22,7 +22,7 @@ export default ({ className, ...props }) => {
 
   return (
     <BaseCodeBox
-      onCopy={navigator.clipboard?.writeText}
+      onCopy={text => navigator.clipboard?.writeText(text)}
       language={getLanguageDisplayName(language)}
       className={className}
       copyButtonLabel="Copy to clipboard"


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixes clipboard copy behavior in the web CodeBox by ensuring navigator.clipboard.writeText is called with the correct runtime context.

Previously, the component passed navigator.clipboard?.writeText as a direct method reference. In browser environments, invoking unbound DOM methods can fail with Illegal invocation, causing code-block copy actions to be unreliable. This change wraps the call in a function so copy operations execute consistently.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
1.Updated copy handler to avoid passing an unbound Clipboard API method reference.
2.Verified copy works in browser after change.
3.No console errors observed during manual testing.

## Related Issues
N/A

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
