### PR TITLE
fix(legacy-html): prevent scroll jump when opening header pickers

### DIFF
--- a/src/generators/legacy-html/assets/api.js
+++ b/src/generators/legacy-html/assets/api.js
@@ -97,7 +97,14 @@ const setupPickers = () => {
         parentNode.classList.add('expanded');
         window.addEventListener('click', closeAllPickers);
         window.addEventListener('keydown', handleEscKey);
-        parentNode.querySelector('.picker a').focus();
+        const firstLink = parentNode.querySelector('.picker a');
+        if (firstLink) {
+          try {
+            firstLink.focus({ preventScroll: true });
+          } catch {
+            firstLink.focus();
+          }
+        }
       });
     });
   });


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixes an unintended page scroll jump when opening sticky header picker dropdowns in legacy HTML docs.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
I reproduced and verified on a generated legacy HTML page (out/fs.html) and in browser behavior matching the reported scenario.

### Reproduction steps
Open an API docs page.
Scroll to the middle of the page.
Open sticky header pickers (Table of contents, Index, Other versions, Options).
### Before

https://github.com/user-attachments/assets/0dba1eb7-c987-4004-a6d5-21558b8cbb25


Opening a picker causes the page to jump upward unexpectedly.

### After

https://github.com/user-attachments/assets/da6a034e-dee3-4ba8-91a9-dca84899b929


Opening a picker no longer changes scroll position; only the dropdown opens.


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixes #764

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
