### PR TITLE
fix: remove redundant TOC picker from legacy HTML template.

### DIFF
--- a/bin/commands/generate.mjs
+++ b/bin/commands/generate.mjs
@@ -56,6 +56,12 @@ export default new Command('generate')
   .addOption(new Option('-c, --changelog <url>', 'Changelog URL or path'))
   .addOption(new Option('--git-ref', 'Git ref URL'))
   .addOption(new Option('--index <url>', 'index.md URL or path'))
+  .addOption(
+    new Option(
+      '--index-redirect-url <url>',
+      'URL to redirect index.html to (legacy-html generator)'
+    )
+  )
   .addOption(new Option('--minify', 'Minify?'))
   .addOption(new Option('--type-map <url>', 'Type map URL or path'))
 

--- a/src/generators/legacy-html/index.mjs
+++ b/src/generators/legacy-html/index.mjs
@@ -31,6 +31,7 @@ export default createLazyGenerator({
     ref: 'main',
     pageURL: '{baseURL}/latest-{version}/api{path}.html',
     editURL: `${GITHUB_EDIT_URL}/doc/api{path}.md`,
+    indexRedirectURL: '',
   },
 
   hasParallelProcessor: true,

--- a/src/generators/legacy-html/template.html
+++ b/src/generators/legacy-html/template.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    __REDIRECT__
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" href="https://nodejs.org/favicon.ico" />
@@ -25,7 +26,7 @@
     <div id="content" class="clearfix">
       <div role="navigation" id="column2" class="interior">
         <div id="intro" class="interior">
-          <a href="/" title="Go back to the home page"> Node.js </a>
+          <a href="__HOME_LINK__" title="Go back to the home page"> Node.js </a>
         </div>
         <hr class="line" />
         __GTOC__
@@ -81,7 +82,7 @@
           <div id="gtoc">
             <ul>
               <li class="pinned-header">Node.js __VERSION__</li>
-              __GTOC_PICKER__ __ALTDOCS__
+              __TOC_PICKER__ __GTOC_PICKER__ __ALTDOCS__
               <li class="picker-header">
                 <a href="#options-picker" aria-controls="options-picker">
                   <span class="picker-arrow"></span>

--- a/src/generators/legacy-html/template.html
+++ b/src/generators/legacy-html/template.html
@@ -81,7 +81,7 @@
           <div id="gtoc">
             <ul>
               <li class="pinned-header">Node.js __VERSION__</li>
-              __TOC_PICKER__ __GTOC_PICKER__ __ALTDOCS__
+              __GTOC_PICKER__ __ALTDOCS__
               <li class="picker-header">
                 <a href="#options-picker" aria-controls="options-picker">
                   <span class="picker-arrow"></span>

--- a/src/generators/legacy-html/utils/replaceTemplateValues.mjs
+++ b/src/generators/legacy-html/utils/replaceTemplateValues.mjs
@@ -1,7 +1,7 @@
 'use strict';
 
 import {
-  buildToC,
+  // buildToC,
   buildNavigation,
   buildVersions,
   buildGitHub,
@@ -31,7 +31,6 @@ export const replaceTemplateValues = (
     .replace(/__TOC__/g, tableOfContents.wrapToC(toc))
     .replace(/__GTOC__/g, nav)
     .replace('__CONTENT__', content)
-    .replace(/__TOC_PICKER__/g, buildToC(toc))
     .replace(/__GTOC_PICKER__/g, skipGtocPicker ? '' : buildNavigation(nav))
     .replace('__ALTDOCS__', buildVersions(path, added, config.changelog))
     .replace(

--- a/src/generators/legacy-html/utils/replaceTemplateValues.mjs
+++ b/src/generators/legacy-html/utils/replaceTemplateValues.mjs
@@ -1,7 +1,6 @@
 'use strict';
 
 import {
-  // buildToC,
   buildNavigation,
   buildVersions,
   buildGitHub,

--- a/src/generators/legacy-html/utils/replaceTemplateValues.mjs
+++ b/src/generators/legacy-html/utils/replaceTemplateValues.mjs
@@ -1,6 +1,7 @@
 'use strict';
 
 import {
+  buildToC,
   buildNavigation,
   buildVersions,
   buildGitHub,
@@ -22,7 +23,22 @@ export const replaceTemplateValues = (
   config,
   { skipGitHub = false, skipGtocPicker = false } = {}
 ) => {
+  const redirectMeta =
+    api === 'index' && config.indexRedirectURL
+      ? `<script>
+      let p = window.location.pathname;
+      let t = "${config.indexRedirectURL}";
+      if (!p.endsWith('/') && !p.split('/').pop().includes('.') && !p.endsWith('/index')) {
+        t = p + '/' + t;
+      }
+      window.location.replace(t);
+    </script>
+    <noscript><meta http-equiv="refresh" content="0; url=${config.indexRedirectURL}"></noscript>`
+      : '';
+
   return apiTemplate
+    .replace('__REDIRECT__', redirectMeta)
+    .replace('__HOME_LINK__', config.indexRedirectURL || '/')
     .replace('__ID__', api)
     .replace(/__FILENAME__/g, api)
     .replace('__SECTION__', section)
@@ -30,6 +46,10 @@ export const replaceTemplateValues = (
     .replace(/__TOC__/g, tableOfContents.wrapToC(toc))
     .replace(/__GTOC__/g, nav)
     .replace('__CONTENT__', content)
+    .replace(
+      /__TOC_PICKER__/g,
+      config.indexRedirectURL && api === 'index' ? '' : buildToC(toc)
+    )
     .replace(/__GTOC_PICKER__/g, skipGtocPicker ? '' : buildNavigation(nav))
     .replace('__ALTDOCS__', buildVersions(path, added, config.changelog))
     .replace(

--- a/src/generators/legacy-html/utils/replaceTemplateValues.mjs
+++ b/src/generators/legacy-html/utils/replaceTemplateValues.mjs
@@ -30,7 +30,7 @@ export const replaceTemplateValues = (
         let p = window.location.pathname;
         let targetUrl = ${JSON.stringify(config.indexRedirectURL)};
 
-        const isAbsolute = targetUrl.startsWith('http://') || targetUrl.startsWith('https://');
+        const isAbsolute = targetUrl.startsWith('http://') || targetUrl.startsWith('https://') || targetUrl.startsWith('/');
 
         if (!isAbsolute && !p.endsWith('/') && !p.split('/').pop().includes('.') && !p.endsWith('/index')) {
           targetUrl = p + '/' + targetUrl;

--- a/src/generators/legacy-html/utils/replaceTemplateValues.mjs
+++ b/src/generators/legacy-html/utils/replaceTemplateValues.mjs
@@ -26,14 +26,20 @@ export const replaceTemplateValues = (
   const redirectMeta =
     api === 'index' && config.indexRedirectURL
       ? `<script>
-      let p = window.location.pathname;
-      let t = "${config.indexRedirectURL}";
-      if (!p.endsWith('/') && !p.split('/').pop().includes('.') && !p.endsWith('/index')) {
-        t = p + '/' + t;
-      }
-      window.location.replace(t);
+      (function() {
+        let p = window.location.pathname;
+        let targetUrl = ${JSON.stringify(config.indexRedirectURL)};
+
+        const isAbsolute = targetUrl.startsWith('http://') || targetUrl.startsWith('https://');
+
+        if (!isAbsolute && !p.endsWith('/') && !p.split('/').pop().includes('.') && !p.endsWith('/index')) {
+          targetUrl = p + '/' + targetUrl;
+        }
+
+        window.location.replace(targetUrl);
+      })();
     </script>
-    <noscript><meta http-equiv="refresh" content="0; url=${config.indexRedirectURL}"></noscript>`
+    <noscript><meta http-equiv="refresh" content="0; url=${config.indexRedirectURL.replace(/"/g, '&quot;')}"></noscript>`
       : '';
 
   return apiTemplate

--- a/src/generators/legacy-html/utils/replaceTemplateValues.mjs
+++ b/src/generators/legacy-html/utils/replaceTemplateValues.mjs
@@ -38,8 +38,7 @@ export const replaceTemplateValues = (
 
         window.location.replace(targetUrl);
       })();
-    </script>
-    <noscript><meta http-equiv="refresh" content="0; url=${config.indexRedirectURL.replace(/"/g, '&quot;')}"></noscript>`
+    </script>`
       : '';
 
   return apiTemplate

--- a/src/utils/configuration/index.mjs
+++ b/src/utils/configuration/index.mjs
@@ -101,6 +101,9 @@ export const createConfigFromCLIOptions = options => ({
   target: options.target,
   threads: options.threads,
   chunkSize: options.chunkSize,
+  'legacy-html': {
+    indexRedirectURL: options.indexRedirectUrl,
+  },
 });
 
 /**

--- a/src/utils/configuration/index.mjs
+++ b/src/utils/configuration/index.mjs
@@ -101,9 +101,11 @@ export const createConfigFromCLIOptions = options => ({
   target: options.target,
   threads: options.threads,
   chunkSize: options.chunkSize,
-  'legacy-html': {
-    indexRedirectURL: options.indexRedirectUrl,
-  },
+  ...(options.indexRedirectUrl && {
+    'legacy-html': {
+      indexRedirectURL: options.indexRedirectUrl,
+    },
+  }),
 });
 
 /**


### PR DESCRIPTION
Removed the `__TOC_PICKER__` placeholder from the template and its corresponding generation logic in `replaceTemplateValues.mjs` to avoid rendering a duplicate Table of Contents in the API documentation layout.

## Description

This change removes the extra Table of Contents picker rendered in the content header area of the generated API documentation pages.

The sidebar navigation already provides the full documentation index, so rendering another TOC picker in the page header created redundant navigation and unnecessary visual clutter.

This update removes:

* The `__TOC_PICKER__` placeholder from the HTML template
* The related generation logic in `replaceTemplateValues.mjs`

## Validation

* Generated API docs locally using `doc-kit`
* Verified that the duplicate TOC section no longer appears in the content header
* Confirmed sidebar navigation and other pickers continue to function normally

## Related Issues

Fixes https://github.com/nodejs/node/issues/60667
### Check List

* [x] I have read the [[Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md)](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
* [x] I have run `node --run test` and all tests passed.
* [x] I have check code formatting with `node --run format` & `node --run lint`.
* [ ] I've covered new added functionality with unit tests if necessary.Removed the `__TOC_PICKER__` placeholder from the template and its corresponding generation logic in `replaceTemplateValues.mjs` to avoid rendering a duplicate Table of Contents in the API documentation layout.