### PR TITLE
metadata: preserve CLI flag anchors

### DIFF
--- a/src/generators/metadata/constants.mjs
+++ b/src/generators/metadata/constants.mjs
@@ -11,9 +11,9 @@ export const DOC_API_SLUGS_REPLACEMENTS = [
   { from: /node.js/i, to: 'nodejs' }, // Replace Node.js
   { from: /&/, to: '-and-' }, // Replace &
   { from: /[/,:;\\ ]/g, to: '-' }, // Replace /,:;\. and whitespace
-  { from: /^-+(?!-*$)/g, to: '' }, // Remove any leading hyphens
+  { from: /^-(?!-|$)/g, to: '' }, // Remove a single leading hyphen
   { from: /(?<!^-*)-+$/g, to: '' }, // Remove any trailing hyphens
-  { from: /^(?!-+$).*?(--+)/g, to: '-' }, // Replace multiple hyphens
+  { from: /^(?!-)(?!-+$).*?(--+)/g, to: '-' }, // Replace multiple hyphens
 ];
 
 // These are regular expressions used to determine if a given Markdown heading

--- a/src/generators/metadata/utils/__tests__/slugger.test.mjs
+++ b/src/generators/metadata/utils/__tests__/slugger.test.mjs
@@ -51,8 +51,8 @@ describe('slug', () => {
       assert.strictEqual(slug('-foo', identity), 'foo');
     });
 
-    it('removes multiple leading hyphens', () => {
-      assert.strictEqual(slug('--foo', identity), 'foo');
+    it('preserves multiple leading hyphens', () => {
+      assert.strictEqual(slug('--permission', identity), '--permission');
     });
 
     it('preserves an all-hyphen string', () => {
@@ -77,6 +77,10 @@ describe('slug', () => {
 
     it('does not fire on an all-hyphen string', () => {
       assert.strictEqual(slug('---', identity), '---');
+    });
+
+    it('does not collapse leading double hyphen flags', () => {
+      assert.strictEqual(slug('--allow-fs-read', identity), '--allow-fs-read');
     });
   });
 


### PR DESCRIPTION
Fixes #757.

Preserves generated anchors for CLI flags that start with `--`, while keeping the existing single-leading-hyphen cleanup.

Checks:
- npm ci
- npm test -- src/generators/metadata/utils/__tests__/slugger.test.mjs
- npm run format:check -- src/generators/metadata/constants.mjs src/generators/metadata/utils/__tests__/slugger.test.mjs
- npm run lint
- git diff --check
