### PR TITLE
fix(web): use base URL for synthetic page assets

### DIFF
--- a/src/generators/web/utils/__tests__/processing.test.mjs
+++ b/src/generators/web/utils/__tests__/processing.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { setConfig } from '../../../../utils/configuration/index.mjs';
+import {
+  default as getConfig,
+  setConfig,
+} from '../../../../utils/configuration/index.mjs';
 import { populateWithEvaluation, resolvePageRoot } from '../processing.mjs';
 
 await setConfig({
@@ -80,11 +83,23 @@ describe('resolvePageRoot', () => {
     assert.strictEqual(result, '../');
   });
 
-  it('uses the configured base URL for synthetic pages', () => {
+  it('uses the server root for synthetic pages', () => {
+    const result = resolvePageRoot({
+      path: '/404',
+      synthetic: true,
+    });
+    assert.strictEqual(result, '/');
+  });
+
+  it('uses the configured base URL for synthetic pages with absolute URLs', async () => {
+    getConfig('web').useAbsoluteURLs = true;
+
     const result = resolvePageRoot({
       path: '/404',
       synthetic: true,
     });
     assert.strictEqual(result, 'https://nodejs.org/docs/');
+
+    getConfig('web').useAbsoluteURLs = false;
   });
 });

--- a/src/generators/web/utils/__tests__/processing.test.mjs
+++ b/src/generators/web/utils/__tests__/processing.test.mjs
@@ -1,7 +1,19 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { populateWithEvaluation } from '../processing.mjs';
+import { setConfig } from '../../../../utils/configuration/index.mjs';
+import { populateWithEvaluation, resolvePageRoot } from '../processing.mjs';
+
+await setConfig({
+  version: 'v22.0.0',
+  changelog: [],
+  generators: {
+    web: {
+      useAbsoluteURLs: false,
+      baseURL: 'https://nodejs.org/docs',
+    },
+  },
+});
 
 describe('populateWithEvaluation', () => {
   it('substitutes simple ${variable} placeholders', () => {
@@ -59,5 +71,20 @@ describe('populateWithEvaluation', () => {
   it('handles numeric values', () => {
     const result = populateWithEvaluation('count: ${count}', { count: 42 });
     assert.strictEqual(result, 'count: 42');
+  });
+});
+
+describe('resolvePageRoot', () => {
+  it('keeps relative roots for regular pages', () => {
+    const result = resolvePageRoot({ path: '/api/fs' });
+    assert.strictEqual(result, '../');
+  });
+
+  it('uses the configured base URL for synthetic pages', () => {
+    const result = resolvePageRoot({
+      path: '/404',
+      synthetic: true,
+    });
+    assert.strictEqual(result, 'https://nodejs.org/docs/');
   });
 });

--- a/src/generators/web/utils/processing.mjs
+++ b/src/generators/web/utils/processing.mjs
@@ -37,7 +37,8 @@ export const populateWithEvaluation = (template, config) => {
  */
 export const resolvePageRoot = data => {
   if (data.synthetic === true) {
-    return String(getConfig('web').baseURL).replace(/\/?$/, '/');
+    const { baseURL, useAbsoluteURLs } = getConfig('web');
+    return useAbsoluteURLs ? String(baseURL).replace(/\/?$/, '/') : '/';
   }
 
   const unresolvedRoot = relativeOrAbsolute('/', data.path);

--- a/src/generators/web/utils/processing.mjs
+++ b/src/generators/web/utils/processing.mjs
@@ -32,6 +32,19 @@ export const populateWithEvaluation = (template, config) => {
 };
 
 /**
+ * @param {import('../../metadata/types').MetadataEntry} data
+ * @returns {string}
+ */
+export const resolvePageRoot = data => {
+  if (data.synthetic === true) {
+    return String(getConfig('web').baseURL).replace(/\/?$/, '/');
+  }
+
+  const unresolvedRoot = relativeOrAbsolute('/', data.path);
+  return unresolvedRoot.endsWith('/') ? unresolvedRoot : `${unresolvedRoot}/`;
+};
+
+/**
  * Converts JSX AST entries to server and client JavaScript code.
  *
  * @param {Array<import('../../jsx-ast/utils/buildContent.mjs').JSXContent>} entries - JSX AST entries
@@ -131,10 +144,7 @@ export async function processJSXEntries(
   // Step 3: Render final HTML pages
   const results = await Promise.all(
     entries.map(async ({ data }) => {
-      const unresolvedRoot = relativeOrAbsolute('/', data.path);
-      const root = unresolvedRoot.endsWith('/')
-        ? unresolvedRoot
-        : `${unresolvedRoot}/`;
+      const root = resolvePageRoot(data);
 
       // Replace template placeholders with actual content
       const renderedHtml = populateWithEvaluation(template, {


### PR DESCRIPTION
Fixes #809

Uses the configured base URL for synthetic page asset roots, so the 404 page can be served from deep links without resolving CSS and JS relative to the missing path.

Checks:
- node --test --experimental-test-module-mocks src\generators\web\utils\__tests__\processing.test.mjs
- npx.cmd eslint src\generators\web\utils\processing.mjs src\generators\web\utils\__tests__\processing.test.mjs
- npx.cmd prettier --check src\generators\web\utils\processing.mjs src\generators\web\utils\__tests__\processing.test.mjs
- git diff --check