### PR TITLE
fix(queries): allow complex types in type linking regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@node-core/doc-kit",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@node-core/doc-kit",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "dependencies": {
         "@actions/core": "^3.0.0",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@node-core/doc-kit",
   "type": "module",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nodejs/doc-kit.git"

--- a/src/utils/queries/__tests__/index.test.mjs
+++ b/src/utils/queries/__tests__/index.test.mjs
@@ -33,6 +33,61 @@ describe('QUERIES', () => {
       strictEqual(QUERIES.standardYamlFrontmatter.test(content), false);
     });
   });
+
+  describe('normalizeTypes', () => {
+    it('matches basic types', () => {
+      const content = '{string}';
+      QUERIES.normalizeTypes.lastIndex = 0;
+      ok(QUERIES.normalizeTypes.test(content));
+    });
+
+    it('matches complex types with generics', () => {
+      const content1 = '{Readonly<object>}';
+      const content2 = '{Map<string, "ignore"|null>}';
+
+      QUERIES.normalizeTypes.lastIndex = 0;
+      ok(
+        QUERIES.normalizeTypes.test(content1),
+        'Should match Readonly<object>'
+      );
+      QUERIES.normalizeTypes.lastIndex = 0;
+      ok(QUERIES.normalizeTypes.test(content2), 'Should match Map<...>');
+    });
+
+    it('matches complex union types with parentheses', () => {
+      const content = '{(string|number)}';
+      QUERIES.normalizeTypes.lastIndex = 0;
+      ok(
+        QUERIES.normalizeTypes.test(content),
+        'Should match union with parentheses'
+      );
+    });
+  });
+
+  describe('linksWithTypes', () => {
+    it('matches basic type links', () => {
+      const content = '[`<string>`](https://mdn...)';
+      QUERIES.linksWithTypes.lastIndex = 0;
+      ok(QUERIES.linksWithTypes.test(content));
+    });
+
+    it('matches complex type links with generics', () => {
+      const content1 =
+        '[`<Readonly>`](https://mdn...)<[`<object>`](https://mdn...)>';
+      QUERIES.linksWithTypes.lastIndex = 0;
+      ok(
+        QUERIES.linksWithTypes.test(content1),
+        'Should match generic type link'
+      );
+    });
+
+    it('matches complex type links with unions', () => {
+      const content2 =
+        '<([`<string>`](https://mdn...)|[`<number>`](https://mdn...))>';
+      QUERIES.linksWithTypes.lastIndex = 0;
+      ok(QUERIES.linksWithTypes.test(content2), 'Should match union type link');
+    });
+  });
 });
 
 describe('UNIST', () => {

--- a/src/utils/queries/index.mjs
+++ b/src/utils/queries/index.mjs
@@ -8,10 +8,10 @@ export const QUERIES = {
   // Fixes the references to Markdown pages into the API documentation
   markdownUrl: /^(?![+a-zA-Z]+:)([^#?]+)\.md(#.+)?$/,
   // ReGeX to match the {Type}<Type> (API type references)
-  normalizeTypes: /(\{|<)(?! )[^<({})>]+(?! )(\}|>)/g,
+  normalizeTypes: /(\{|<)(?! )[^{}]+(?! )(\}|>)/g,
   // ReGex to match the type API type references that got already parsed
   // so that they can be transformed into HTML links
-  linksWithTypes: /\[`<[^<({})>]+>`\]\((\S+)\)/g,
+  linksWithTypes: /\[`<[^{}]+>`\]\((\S+)\)/g,
   // ReGeX for handling Stability Indexes Metadata
   stabilityIndex: /^Stability: ([0-5](?:\.[0-3])?)(?:\s*-\s*)?(.*)$/s,
   // ReGeX for handling the Stability Index Prefix


### PR DESCRIPTION
## Description

Currently, `doc-kit` fails to parse and link complex JSDoc types that contain generics, unions and arrow functions. 

This happens because the regex in `src/utils/queries/index.mjs` uses `[^<({})>]+`, which excludes `<`, `>`, `(`, and `)`. When the parser encounters these characters, it ignores the entire type block, leaving it unlinked and sometimes causing Markdown parsers (Remark) to see them as HTML tags.

This PR updates the regex exclusion list to `[^{}]+`.

## Validation

**Before**:
<img width="1030" height="88" alt="Screenshot from 2026-05-30 15-13-38" src="https://github.com/user-attachments/assets/d2276156-5959-4a5b-8b82-91f7b255b088" />

**After**:
<img width="1030" height="88" alt="Screenshot from 2026-05-30 15-19-35" src="https://github.com/user-attachments/assets/a9d0f4d0-1c24-4c76-ba1a-3fdb178ef692" />


## Related Issues

No related one.

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
