### PR TITLE
fix(metadata): add missing void and iterable types to builtin map

### DIFF
--- a/src/generators/metadata/maps/builtin.json
+++ b/src/generators/metadata/maps/builtin.json
@@ -1,5 +1,7 @@
 {
   "asynciterable": "https://tc39.github.io/ecma262/#sec-asynciterable-interface",
+  "iterable": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol",
+  "void": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/void",
   "module namespace object": "https://tc39.github.io/ecma262/#sec-module-namespace-exotic-objects",
   "null": "https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#null_type",
   "undefined": "https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#undefined_type",

--- a/src/generators/metadata/utils/__tests__/transformers.test.mjs
+++ b/src/generators/metadata/utils/__tests__/transformers.test.mjs
@@ -55,10 +55,13 @@ describe('transformTypeToReferenceLink', () => {
     );
   });
 
-  it('should handle outer unions with generics like {Promise<string|number> | boolean}', () => {
+  it('should handle outer unions with generics like {Promise<string|number> | Iterable<boolean>}', () => {
     strictEqual(
-      transformTypeToReferenceLink('{Promise<string|number> | boolean}', {}),
-      '[`<Promise>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type) | [`<number>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#number_type)&gt; | [`<boolean>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#boolean_type)'
+      transformTypeToReferenceLink(
+        '{Promise<string|number> | Iterable<boolean>}',
+        {}
+      ),
+      '[`<Promise>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type) | [`<number>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#number_type)&gt; | [`<Iterable>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol)&lt;[`<boolean>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#boolean_type)&gt;'
     );
   });
 
@@ -105,7 +108,7 @@ describe('transformTypeToReferenceLink', () => {
       '(cb: ([first, second]: string[]) => void) => ({ id, name }: User) => boolean';
 
     const expected =
-      '(cb: ([first, second]: [`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type)[]) =&gt; `<void>`) =&gt; ({ id, name }: [`<User>`](userLink)) =&gt; [`<boolean>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#boolean_type)';
+      '(cb: ([first, second]: [`<string>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#string_type)[]) =&gt; [`<void>`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/void)) =&gt; ({ id, name }: [`<User>`](userLink)) =&gt; [`<boolean>`](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures#boolean_type)';
 
     strictEqual(
       transformTypeToReferenceLink(input, { User: 'userLink' }),


### PR DESCRIPTION
## Description

While generating docs using `doc-kit`, native types like `void and Iterable` failed to resolve to their MDN references because they were missing from the `builtin.json` map. This PR adds them so they resolve correctly across projects using doc-kit.

## Validation

Add tests for them in `transformers.mjs`.

## Related Issues

None

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `node --run test` and all tests passed.
- [X] I have check code formatting with `node --run format` & `node --run lint`.
- [X] I've covered new added functionality with unit tests if necessary.
