### PR TITLE
refactor(docs): remove interactive command references from README and commands documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ Options:
   -h, --help                 display help for command
 ```
 
-
 ## Examples
 
 ### Legacy

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Options:
 
 Commands:
   generate [options]  Generate API docs
-  interactive         Launch guided CLI wizard
   help [command]      display help for command
 ```
 
@@ -72,16 +71,6 @@ Options:
   -h, --help                 display help for command
 ```
 
-### `interactive`
-
-```
-Usage: @node-core/doc-kit interactive [options]
-
-Launch guided CLI wizard
-
-Options:
-  -h, --help  display help for command
-```
 
 ## Examples
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,7 +15,7 @@ interface Command {
 
 Each command consists of:
 
-- **name**: The command name used in the CLI (e.g., `generate`, `interactive`)
+- **name**: The command name used in the CLI (e.g., `generate`)
 - **description**: A short description shown in help text
 - **options**: An object mapping option names to their definitions
 - **action**: The async function that executes when the command is run
@@ -57,12 +57,10 @@ Add your command to the exports in `bin/commands/index.mjs`:
 
 ```javascript
 import generate from './generate.mjs';
-import interactive from './interactive.mjs';
 import myCommand from './my-command.mjs'; // Add this
 
 export default [
   generate,
-  interactive,
   myCommand, // Add this
 ];
 ```
@@ -79,7 +77,6 @@ Options define the flags and parameters your command accepts. Each option has:
 interface Option {
   flags: string[]; // CLI flags (e.g., ['-i', '--input <value>'])
   desc: string; // Description for help text
-  prompt?: PromptConfig; // Interactive mode configuration
 }
 ```
 
@@ -185,39 +182,4 @@ prompt: {
     { label: 'Choice B', value: 'b' },
   ],
 }
-```
-
-## Interactive Prompts
-
-The `interactive` command automatically uses the `prompt` configuration from your options. When users run:
-
-```bash
-doc-kit interactive
-```
-
-They'll be prompted to select a command, then guided through all required options.
-
-### Prompt Configuration
-
-- **message**: Question to ask the user
-- **type**: Input type (`text`, `confirm`, `select`, `multiselect`)
-- **required**: Whether the field must have a value
-- **initialValue**: Default value
-- **variadic**: Whether multiple values can be entered (for `text` type)
-- **options**: Choices for `select`/`multiselect` types
-
-### Making Options Interactive-Friendly
-
-Always provide helpful messages and sensible defaults:
-
-```javascript
-threads: {
-  flags: ['-p', '--threads <number>'],
-  desc: 'Number of threads to use (minimum: 1)',
-  prompt: {
-    type: 'text',
-    message: 'How many threads to allow',
-    initialValue: String(cpus().length),  // Smart default
-  },
-},
 ```


### PR DESCRIPTION
 

<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Some remaining references to `interactive` - this was throwing me off as I was walking the docs

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

closed #849

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
