### PR TITLE
feat(404): add customizable not found page text and link options

### DIFF
--- a/src/generators/jsx-ast/README.md
+++ b/src/generators/jsx-ast/README.md
@@ -13,3 +13,6 @@ The `jsx-ast` generator accepts the following configuration options:
 | `generateAllPage`      | `boolean` | `true`   | When `true`, creates a synthetic JSX AST entry for `all.html`            |
 | `generateIndexPage`    | `boolean` | `true`   | When `true`, creates a synthetic JSX AST entry for `index.html`          |
 | `generateNotFoundPage` | `boolean` | `true`   | When `true`, creates a synthetic JSX AST entry for `404.html`            |
+| `notFoundText`         | `string`  | `'The page you requested could not be found. Use the navigation to find the documentation you are looking for, or return to the '` | Lead-in text shown before the link on the synthetic `404.html` page |
+| `notFoundLinkUrl`      | `string`  | `'index.html'` | URL of the link shown on the synthetic `404.html` page            |
+| `notFoundLinkText`     | `string`  | `'API index'` | Text of the link shown on the synthetic `404.html` page             |

--- a/src/generators/jsx-ast/README.md
+++ b/src/generators/jsx-ast/README.md
@@ -6,13 +6,13 @@ The `jsx-ast` generator converts MDAST (Markdown Abstract Syntax Tree) to JSX AS
 
 The `jsx-ast` generator accepts the following configuration options:
 
-| Name                   | Type      | Default  | Description                                                              |
-| ---------------------- | --------- | -------- | ------------------------------------------------------------------------ |
-| `ref`                  | `string`  | `'main'` | Git reference/branch for linking to source files                         |
-| `index`                | `array`   | -        | Array of `{ section, api }` objects defining the documentation structure |
-| `generateAllPage`      | `boolean` | `true`   | When `true`, creates a synthetic JSX AST entry for `all.html`            |
-| `generateIndexPage`    | `boolean` | `true`   | When `true`, creates a synthetic JSX AST entry for `index.html`          |
-| `generateNotFoundPage` | `boolean` | `true`   | When `true`, creates a synthetic JSX AST entry for `404.html`            |
-| `notFoundText`         | `string`  | `'The page you requested could not be found. Use the navigation to find the documentation you are looking for, or return to the '` | Lead-in text shown before the link on the synthetic `404.html` page |
-| `notFoundLinkUrl`      | `string`  | `'index.html'` | URL of the link shown on the synthetic `404.html` page            |
-| `notFoundLinkText`     | `string`  | `'API index'` | Text of the link shown on the synthetic `404.html` page             |
+| Name                   | Type      | Default                                                                                                                            | Description                                                              |
+| ---------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `ref`                  | `string`  | `'main'`                                                                                                                           | Git reference/branch for linking to source files                         |
+| `index`                | `array`   | -                                                                                                                                  | Array of `{ section, api }` objects defining the documentation structure |
+| `generateAllPage`      | `boolean` | `true`                                                                                                                             | When `true`, creates a synthetic JSX AST entry for `all.html`            |
+| `generateIndexPage`    | `boolean` | `true`                                                                                                                             | When `true`, creates a synthetic JSX AST entry for `index.html`          |
+| `generateNotFoundPage` | `boolean` | `true`                                                                                                                             | When `true`, creates a synthetic JSX AST entry for `404.html`            |
+| `notFoundText`         | `string`  | `'The page you requested could not be found. Use the navigation to find the documentation you are looking for, or return to the '` | Lead-in text shown before the link on the synthetic `404.html` page      |
+| `notFoundLinkUrl`      | `string`  | `'index.html'`                                                                                                                     | URL of the link shown on the synthetic `404.html` page                   |
+| `notFoundLinkText`     | `string`  | `'API index'`                                                                                                                      | Text of the link shown on the synthetic `404.html` page                  |

--- a/src/generators/jsx-ast/generate.mjs
+++ b/src/generators/jsx-ast/generate.mjs
@@ -22,7 +22,7 @@ const buildSyntheticDescriptors = input => {
   return [
     config.generateAllPage && buildAllPage(input),
     config.generateIndexPage && buildIndexPage(input),
-    config.generateNotFoundPage && buildNotFoundPage(),
+    config.generateNotFoundPage && buildNotFoundPage(config),
   ].filter(Boolean);
 };
 

--- a/src/generators/jsx-ast/index.mjs
+++ b/src/generators/jsx-ast/index.mjs
@@ -1,5 +1,6 @@
 'use strict';
 
+import { NOT_FOUND_DEFAULTS } from './utils/synthetic/404.mjs';
 import { createLazyGenerator } from '../../utils/generators.mjs';
 
 /**
@@ -21,6 +22,7 @@ export default createLazyGenerator({
     generateAllPage: true,
     generateIndexPage: true,
     generateNotFoundPage: true,
+    ...NOT_FOUND_DEFAULTS,
   },
 
   hasParallelProcessor: true,

--- a/src/generators/jsx-ast/types.d.ts
+++ b/src/generators/jsx-ast/types.d.ts
@@ -7,6 +7,9 @@ export type Generator = GeneratorMetadata<
     generateAllPage: boolean;
     generateIndexPage: boolean;
     generateNotFoundPage: boolean;
+    notFoundText: string;
+    notFoundLinkUrl: string;
+    notFoundLinkText: string;
   },
   Generate<Array<MetadataEntry>, AsyncGenerator<JSXContent>>,
   ProcessChunk<

--- a/src/generators/jsx-ast/utils/synthetic/404.mjs
+++ b/src/generators/jsx-ast/utils/synthetic/404.mjs
@@ -3,9 +3,29 @@
 import { createSyntheticHead, wrapAsEntry } from './synthetic.mjs';
 
 /**
- * Builds the page descriptor for `404.html`
+ * Default configuration for the synthetic `404.html` page. Re-exported so the
+ * `jsx-ast` generator's `defaultConfiguration` can reuse the same values
+ * instead of duplicating them.
  */
-export const buildNotFoundPage = () => {
+export const NOT_FOUND_DEFAULTS = {
+  notFoundText:
+    'The page you requested could not be found. Use the navigation to find the documentation you are looking for, or return to the ',
+  notFoundLinkUrl: 'index.html',
+  notFoundLinkText: 'API index',
+};
+
+/**
+ * Builds the page descriptor for `404.html`
+ *
+ * @param {Partial<Pick<import('../../types').Generator['defaultConfiguration'], 'notFoundText' | 'notFoundLinkUrl' | 'notFoundLinkText'>>} config
+ */
+export const buildNotFoundPage = (config = {}) => {
+  const {
+    notFoundText = NOT_FOUND_DEFAULTS.notFoundText,
+    notFoundLinkUrl = NOT_FOUND_DEFAULTS.notFoundLinkUrl,
+    notFoundLinkText = NOT_FOUND_DEFAULTS.notFoundLinkText,
+  } = config;
+
   const head = createSyntheticHead('404', 'Page Not Found');
 
   return {
@@ -17,13 +37,12 @@ export const buildNotFoundPage = () => {
           children: [
             {
               type: 'text',
-              value:
-                'The page you requested could not be found. Use the navigation to find the documentation you are looking for, or return to the ',
+              value: notFoundText,
             },
             {
               type: 'link',
-              url: 'index.html',
-              children: [{ type: 'text', value: 'API index' }],
+              url: notFoundLinkUrl,
+              children: [{ type: 'text', value: notFoundLinkText }],
             },
             {
               type: 'text',

--- a/src/generators/jsx-ast/utils/synthetic/__tests__/404.test.mjs
+++ b/src/generators/jsx-ast/utils/synthetic/__tests__/404.test.mjs
@@ -45,4 +45,23 @@ describe('buildNotFoundPage', () => {
     assert.deepEqual(a.head, b.head);
     assert.equal(a.entries.length, b.entries.length);
   });
+
+  it('honors custom text and link configuration', () => {
+    const { entries } = buildNotFoundPage({
+      notFoundText: 'Nothing here. Go back to the ',
+      notFoundLinkUrl: 'home.html',
+      notFoundLinkText: 'homepage',
+    });
+
+    const paragraph = entries[0].content.children.find(
+      child => child.type === 'paragraph'
+    );
+
+    assert.equal(paragraph.children[0].value, 'Nothing here. Go back to the ');
+
+    const link = paragraph.children.find(child => child.type === 'link');
+
+    assert.equal(link.url, 'home.html');
+    assert.equal(link.children[0].value, 'homepage');
+  });
 });


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Considered how to quickly customize the 404 text. This was chosen over a larger scale - user provided 404 page.
Responsible AI disclosure: authored in partnership with Claude Code and hand-reviewed by an organic human.

This was useful for me to continue to catch up on how doc-kit has evolved while I have been spread thin.

## Validation

Unit tests

## Related Issues

closes #877

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
