### PR TITLE
fix(jsx-ast): alpha-sort stability overview

### DIFF
--- a/src/generators/jsx-ast/utils/synthetic/__tests__/index.test.mjs
+++ b/src/generators/jsx-ast/utils/synthetic/__tests__/index.test.mjs
@@ -30,6 +30,22 @@ describe('buildIndexPage', () => {
     assert.equal(head.heading.data.name, 'Index');
     assert.equal(head.synthetic, true);
   });
+
+  it('sorts the stability overview rows alphabetically by API name', () => {
+    const { entries } = buildIndexPage([
+      fakeHead('fs', 'fs', 2),
+      fakeHead('assert', 'assert', 2),
+      fakeHead('crypto', 'crypto', 2),
+    ]);
+
+    const table = findChild(entries[0].content, 'table');
+    const rows = findChild(table, 'tbody').children;
+    const names = rows.map(
+      row => row.children[0].children[0].children[0].value
+    );
+
+    assert.deepEqual(names, ['assert', 'crypto', 'fs']);
+  });
 });
 
 describe('buildStabilityOverview', () => {

--- a/src/generators/jsx-ast/utils/synthetic/index.mjs
+++ b/src/generators/jsx-ast/utils/synthetic/index.mjs
@@ -5,6 +5,7 @@ import { h as createElement } from 'hastscript';
 import { createSyntheticHead, wrapAsEntry } from './synthetic.mjs';
 import { JSX_IMPORTS } from '../../../web/constants.mjs';
 import { createJSXElement } from '../ast.mjs';
+import { getSortedHeadNodes } from '../getSortedHeadNodes.mjs';
 
 const STABILITY_BADGE_KINDS = [
   'error',
@@ -67,7 +68,7 @@ export const buildStabilityOverview = headEntries =>
  */
 export const buildIndexPage = entries => {
   const head = createSyntheticHead('index', 'Index');
-  const moduleEntries = entries.filter(entry => entry.heading.depth === 1);
+  const moduleEntries = getSortedHeadNodes(entries);
 
   return {
     head,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Comparing https://beta.docs.nodejs.org/index.html and https://nodejs.org/docs/latest/api/documentation.html#stability-overview revealed the API stability list inconsistently sorted.

> AI Disclosure. Built in coordination with Claude Code Opus and manually reviewed by me.

## Validation

| Current Docs | Beta | PR |
| - | - | - |
| <img width="414" height="678" alt="image" src="https://github.com/user-attachments/assets/1bdd1120-6820-40f5-813f-8f6cf551e4a6" /> | <img width="906" height="583" alt="image" src="https://github.com/user-attachments/assets/54a05251-8312-4f9f-a1e8-97f296594f9b" /> | <img width="907" height="575" alt="image" src="https://github.com/user-attachments/assets/19a668d5-db8d-49d7-95a3-9c80aa014df4" />

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
