### PR TITLE
fix(metadata): support TS prefix operators in typeParser

### DIFF
--- a/src/generators/metadata/constants.mjs
+++ b/src/generators/metadata/constants.mjs
@@ -1,6 +1,7 @@
 // These openers/closers are used to determine if a type string is well-formed
 export const TYPE_OPENERS = new Set(['<', '(', '{', '[']);
 export const TYPE_CLOSERS = new Set(['>', ')', '}', ']']);
+export const PREFIXES = ['typeof ', 'keyof ', 'readonly ', 'unique '];
 
 // On "About this Documentation", we define the stability indices, and thus
 // we don't need to check it for stability references

--- a/src/generators/metadata/utils/__tests__/transformers.test.mjs
+++ b/src/generators/metadata/utils/__tests__/transformers.test.mjs
@@ -93,6 +93,24 @@ describe('transformTypeToReferenceLink', () => {
     );
   });
 
+  it('should correctly extract TS prefix operators and link the underlying type', () => {
+    strictEqual(
+      transformTypeToReferenceLink('typeof Compiler', {
+        Compiler: '/api/Compiler',
+      }),
+      'typeof [`<Compiler>`](/api/Compiler)'
+    );
+  });
+
+  it('should not incorrectly strip prefixes if they are part of the type name (word boundary)', () => {
+    strictEqual(
+      transformTypeToReferenceLink('typeofSomething', {
+        typeofSomething: '/api/typeofSomething',
+      }),
+      '[`<typeofSomething>`](/api/typeofSomething)'
+    );
+  });
+
   it('should handle extreme nested combinations of functions, arrays, generics, unions, and intersections', () => {
     const input =
       '(str: string[]) => Promise<Map<string, number & string>, Map<string | number>>';

--- a/src/generators/metadata/utils/typeParser.mjs
+++ b/src/generators/metadata/utils/typeParser.mjs
@@ -206,6 +206,14 @@ export const parseType = (typeString, transformType) => {
     return parts.map(p => resolveOr(p, transformType)).join(joiner);
   }
 
+  const PREFIXES = ['typeof ', 'keyof ', 'readonly ', 'unique '];
+  for (const prefix of PREFIXES) {
+    if (trimmed.startsWith(prefix)) {
+      const rest = trimmed.slice(prefix.length).trim();
+      return `${prefix.trim()} ${resolveOr(rest, transformType)}`;
+    }
+  }
+
   // Strip a trailing `[]` for now; reapply on the way out.
   const isArray = trimmed.endsWith('[]');
   const core = isArray ? trimmed.slice(0, -2).trim() : trimmed;

--- a/src/generators/metadata/utils/typeParser.mjs
+++ b/src/generators/metadata/utils/typeParser.mjs
@@ -1,4 +1,4 @@
-import { TYPE_OPENERS, TYPE_CLOSERS } from '../constants.mjs';
+import { TYPE_OPENERS, TYPE_CLOSERS, PREFIXES } from '../constants.mjs';
 
 /** True when the `>` at `i` is the tail of `=>` and shouldn't pop depth. */
 const isArrowTail = (str, i) => str[i] === '>' && str[i - 1] === '=';
@@ -206,7 +206,6 @@ export const parseType = (typeString, transformType) => {
     return parts.map(p => resolveOr(p, transformType)).join(joiner);
   }
 
-  const PREFIXES = ['typeof ', 'keyof ', 'readonly ', 'unique '];
   for (const prefix of PREFIXES) {
     if (trimmed.startsWith(prefix)) {
       const rest = trimmed.slice(prefix.length).trim();


### PR DESCRIPTION
## Description

Currently, the `typeParser` in `src/generators/metadata/utils/typeParser.mjs` fails to resolve types that have prefix operators such as `typeof`, `keyof`, `readonly`, and `unique`.

Because the parser treats the prefix and the target type as a single continuous string (e.g., `"typeof Compiler"`), it fails to find a match in the `type-map`, resulting in dead links and plain text rendering in the documentation.

This PR introduces a check for these common prefix operators before falling back to array or generic processing. It strips the prefix, formats it as plain text, and recursively passes the remaining target type to `resolveOr` so it can be correctly matched and linked.

## Validation

Tested it on `webpack-doc-kit`:

**Before:**
<img width="612" height="272" alt="image" src="https://github.com/user-attachments/assets/3443ad69-969d-4291-810e-308f07ffc8ab" />

**After:**
<img width="612" height="285" alt="image" src="https://github.com/user-attachments/assets/fdf6bf6b-cf80-4590-9546-89ecc66641ea" />

## Related Issues

No related issues.

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `node --run test` and all tests passed.
- [X] I have check code formatting with `node --run format` & `node --run lint`.
- [X] I've covered new added functionality with unit tests if necessary.
