### PR TITLE
shiki: add HTML and CSS language support

### DIFF
--- a/shiki.config.mjs
+++ b/shiki.config.mjs
@@ -4,8 +4,10 @@ import cLanguage from 'shiki/langs/c.mjs';
 import cmakeLanguage from 'shiki/langs/cmake.mjs';
 import coffeeScriptLanguage from 'shiki/langs/coffeescript.mjs';
 import cPlusPlusLanguage from 'shiki/langs/cpp.mjs';
+import cssLanguage from 'shiki/langs/css.mjs';
 import diffLanguage from 'shiki/langs/diff.mjs';
 import dockerLanguage from 'shiki/langs/docker.mjs';
+import htmlLanguage from 'shiki/langs/html.mjs';
 import httpLanguage from 'shiki/langs/http.mjs';
 import javaScriptLanguage from 'shiki/langs/javascript.mjs';
 import jsonLanguage from 'shiki/langs/json.mjs';
@@ -41,6 +43,8 @@ export default {
     ...coffeeScriptLanguage,
     ...cmakeLanguage,
     ...pythonLanguage,
+    ...htmlLanguage,
+    ...cssLanguage,
     { ...javaScriptLanguage[0], aliases: ['mjs', 'cjs', 'js'] },
   ],
 };


### PR DESCRIPTION
## Summary

Registers the HTML and CSS Shiki grammars in `shiki.config.mjs` so fenced code blocks using these languages are picked up and syntax highlighted, as requested in #844.

## Test plan
- [x] Built a highlighter with the updated config and rendered sample `html`/`css` snippets through `codeToHtml` — confirmed correctly colored output for both languages
- [x] `npm test` — no new failures (3 pre-existing failures on this checkout are unrelated Windows path-separator issues, reproducible on `main` as well)
- [x] `npm run lint` — clean (pre-existing unrelated warnings only)