### PR TITLE
ci: skip PR comment step when workflow_run has no pull request

### DIFF
--- a/.github/workflows/leave-comment.yml
+++ b/.github/workflows/leave-comment.yml
@@ -13,6 +13,10 @@ permissions:
 jobs:
   aggregate:
     name: Aggregate Comparison Results
+    # Only pull_request-triggered runs have a PR to comment on; runs triggered
+    # by a plain push to main (e.g. after a merge) have none, and attempting
+    # to comment in that case fails with "No issue/pull request in input".
+    if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Summary

`leave-comment.yml` runs after `Generate and Compare Docs` completes via `workflow_run`. That workflow triggers on both `push` (to `main`) and `pull_request`, but `leave-comment.yml` unconditionally assumes there's a PR to comment on.

For push-triggered runs (e.g. after a merge to `main`), `github.event.workflow_run.pull_requests[0]` is `undefined`, so the `Add Comment to PR` step fails with:

```
No issue/pull request in input neither in current context.
```

Example failing run: https://github.com/nodejs/doc-kit/actions/runs/28747289633/job/85240250539 (triggered by a push to `main`, not a PR).

## Fix

Guard the `aggregate` job with `if: github.event.workflow_run.event == 'pull_request'`, so it only runs (and only attempts to comment) when the triggering workflow run actually originated from a pull request.

## Test plan
- [x] Confirmed via the workflow run logs that the failing run's triggering event was a push to `main`, not a PR, matching this fix's guard condition
- [x] YAML structure/indentation verified by hand and formatted by the repo's own `prettier` pre-commit hook (`*.yml` files are covered by `.lintstagedrc.json`)
- Not verifiable locally end-to-end since `workflow_run` behavior only manifests on GitHub's runners, but the fix directly targets the exact condition (`workflow_run.event`) that caused the observed failure