### PR TITLE
fix(vercel): update vercel scripts to build against latest Node.js release tag

### DIFF
--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -1,3 +1,10 @@
+set -e
+
+# Use the tag captured during the prepare step as the docs version, so the
+# output reflects the nodejs/node release it was generated from (e.g. v26.0.0)
+# rather than the Node.js runtime version running this build (process.version).
+NODE_VERSION=$(cat .node-tag)
+
 node bin/cli.mjs generate \
   -t orama-db \
   -t legacy-json \
@@ -6,6 +13,7 @@ node bin/cli.mjs generate \
   -i "./node/doc/api/*.md" \
   -o "./out" \
   -c "./node/CHANGELOG.md" \
+  -v "$NODE_VERSION" \
   --type-map "./node/doc/type-map.json" \
   --index "./node/doc/api/index.md" \
   --log-level debug
@@ -13,3 +21,4 @@ node bin/cli.mjs generate \
 cp ./node/doc/api/*.md "./out"
 
 rm -rf node/
+rm -f .node-tag

--- a/scripts/vercel-prepare.sh
+++ b/scripts/vercel-prepare.sh
@@ -1,5 +1,24 @@
-# Clone the repository with no checkout and shallow history
-git clone --depth 1 --filter=blob:none --sparse https://github.com/nodejs/node.git
+set -e
+
+# Determine the latest stable release tag on nodejs/node (skip pre-releases
+# like `-rc`/`-nightly`, taking the highest version-sorted tag).
+LATEST_TAG=$(git ls-remote --tags --refs --sort='-v:refname' \
+  https://github.com/nodejs/node.git 'v*' \
+  | awk -F/ '$NF !~ /-/ { print $NF; exit }')
+
+if [ -z "$LATEST_TAG" ]; then
+  echo "Could not determine the latest nodejs/node release tag" >&2
+  exit 1
+fi
+
+# Persist the tag so the build step can use it as the docs version
+echo "$LATEST_TAG" > .node-tag
+
+echo "Building docs for nodejs/node $LATEST_TAG"
+
+# Clone the repository at that tag with no checkout and shallow history
+git clone --depth 1 --branch "$LATEST_TAG" --filter=blob:none --sparse \
+  https://github.com/nodejs/node.git
 
 # Move into the cloned directory
 cd node


### PR DESCRIPTION


<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Per feedback, we should use upstream node latest tagged version, not the `process.version` 

> AI disclosure: Written with the aide of Claude Code Opus. Verified the bash manually.

## Validation

Should build against 26.5.0 at time of writing

## Related Issues

Part of https://github.com/nodejs/nodejs.org/pull/8998

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
