### PR TITLE
fix(web): hide search without Orama data

### DIFF
--- a/.changeset/lazy-tools-search.md
+++ b/.changeset/lazy-tools-search.md
@@ -1,0 +1,5 @@
+---
+'@node-core/doc-kit': patch
+---
+
+Hide the web documentation search control unless the Orama database generator is enabled.

--- a/src/generators.mjs
+++ b/src/generators.mjs
@@ -73,7 +73,9 @@ const createGenerator = () => {
           ? createParallelWorker(generatorName, pool, configuration)
           : Promise.resolve(null);
 
-        const result = await generate(dependencyInput, await worker);
+        const result = await generate(dependencyInput, await worker, {
+          target: configuration.target,
+        });
 
         // For streaming generators, "Completed" is logged when the cache
         // finishes collecting, not here when the generator returns

--- a/src/generators/types.d.ts
+++ b/src/generators/types.d.ts
@@ -40,7 +40,8 @@ declare global {
    */
   export type Generate<I, O> = (
     input: I,
-    worker: ParallelWorker
+    worker: ParallelWorker,
+    context: { target: string[] }
   ) => O extends AsyncGenerator ? O : Promise<O>;
 
   /**

--- a/src/generators/web/README.md
+++ b/src/generators/web/README.md
@@ -13,6 +13,7 @@ The `web` generator accepts the following configuration options:
 | `project`         | `string`  | `'Node.js'`                                   | Project name used in page titles and the version selector                |
 | `title`           | `string`  | `'{project} v{version} Documentation'`        | Title template for HTML pages (supports `{project}`, `{version}`)        |
 | `useAbsoluteURLs` | `boolean` | `false`                                       | When `true`, all internal links use absolute URLs based on `baseURL`     |
+| `showSearchBar`   | `boolean` | Whether `orama-db` is targeted                | Overrides whether the navigation renders the search control              |
 | `editURL`         | `string`  | `'${GITHUB_EDIT_URL}/doc/api{path}.md'`       | URL template for "edit this page" links                                  |
 | `pageURL`         | `string`  | `'{baseURL}/latest-{version}/api{path}.html'` | URL template for documentation page links                                |
 | `head`            | `object`  | See below                                     | Configurable `<meta>`, `<link>`, and raw markup for the document head    |

--- a/src/generators/web/__tests__/generate.test.mjs
+++ b/src/generators/web/__tests__/generate.test.mjs
@@ -45,6 +45,23 @@ const createEntry = (api, name) => {
 };
 
 describe('web generate', () => {
+  it('only renders search when the Orama database is generated', async () => {
+    await setConfig({ target: ['web'] });
+    const fs = createEntry('fs', 'File system');
+    const input = [toCodeItem(await buildContent([fs], fs))];
+
+    const [withoutOrama] = await generate(input, undefined, {
+      target: ['web'],
+    });
+    assert.doesNotMatch(withoutOrama.html, /Start typing/);
+
+    await setConfig({ target: ['web', 'orama-db'] });
+    const [withOrama] = await generate(input, undefined, {
+      target: ['web', 'orama-db'],
+    });
+    assert.match(withOrama.html, /Start typing/);
+  });
+
   it('omits View As links for synthetic pages only', async () => {
     await setConfig({});
 

--- a/src/generators/web/generate.mjs
+++ b/src/generators/web/generate.mjs
@@ -18,7 +18,7 @@ import { writeFile } from '../../utils/file.mjs';
  *
  * @type {import('./types').Generator['generate']}
  */
-export async function generate(input) {
+export async function generate(input, _worker, { target = [] } = {}) {
   const config = getConfig('web');
 
   const template = await readFile(config.templatePath, 'utf-8');
@@ -46,6 +46,7 @@ export async function generate(input) {
     datas,
     sidebarEntries,
     template,
+    searchEnabled: config.showSearchBar ?? target.includes('orama-db'),
   });
 
   if (config.output) {

--- a/src/generators/web/index.mjs
+++ b/src/generators/web/index.mjs
@@ -38,6 +38,7 @@ export default createLazyGenerator({
     editURL: `${GITHUB_EDIT_URL}/doc/api{path}.md`,
     pageURL: '{baseURL}/latest-{version}/api{path}.html',
     remoteConfigUrl: 'https://nodejs.org/site.json',
+    showSearchBar: undefined,
 
     // Project-specific document `<head>` contents. `meta` and `links` are
     // arrays of attribute bags (boolean `true` renders a valueless attribute,

--- a/src/generators/web/types.d.ts
+++ b/src/generators/web/types.d.ts
@@ -31,6 +31,7 @@ export type Configuration = {
   templatePath: string;
   title: string;
   useAbsoluteURLs: boolean;
+  showSearchBar?: boolean;
   head: HeadConfig;
   // Options spread into LightningCSS while bundling CSS. `filename`, `code`,
   // `cssModules`, and `resolver` are managed by the generator and ignored here.

--- a/src/generators/web/ui/components/NavBar.jsx
+++ b/src/generators/web/ui/components/NavBar.jsx
@@ -6,7 +6,7 @@ import GitHubIcon from '@node-core/ui-components/Icons/Social/GitHub';
 import SearchBox from './SearchBox';
 import { useTheme } from '../hooks/useTheme.mjs';
 
-import { repository } from '#theme/config';
+import { repository, searchEnabled } from '#theme/config';
 import Logo from '#theme/Logo';
 
 /**
@@ -21,7 +21,7 @@ export default ({ metadata }) => {
       sidebarItemTogglerAriaLabel="Toggle navigation menu"
       navItems={[]}
     >
-      <SearchBox pathname={metadata.path} />
+      {searchEnabled && <SearchBox pathname={metadata.path} />}
       <ThemeToggle
         onChange={setThemePreference}
         currentTheme={themePreference}

--- a/src/generators/web/utils/config.mjs
+++ b/src/generators/web/utils/config.mjs
@@ -70,9 +70,10 @@ export function buildLanguageDisplayNameMap() {
  * per-page resolution by components).
  *
  * @param {Array<import('../../jsx-ast/utils/buildContent.mjs').JSXContent>} input - JSX AST entries with .data metadata
+ * @param {boolean} searchEnabled - Whether the search control is enabled
  * @returns {string} JavaScript source code string with named exports
  */
-export default function createConfigSource(input) {
+export default function createConfigSource(input, searchEnabled) {
   const { version: configVersion, ...config } = getConfig('web');
 
   const editURL = populate(config.editURL, {
@@ -97,6 +98,7 @@ export default function createConfigSource(input) {
       ]
     ),
     version: configVersion,
+    searchEnabled,
     versions: buildVersionEntries(config.changelog, pageURL),
     editURL,
     pages: buildPageList(input),

--- a/src/generators/web/utils/processing.mjs
+++ b/src/generators/web/utils/processing.mjs
@@ -157,6 +157,7 @@ async function executeServerCode(serverCodeMap, requireFn, virtualImports) {
  * @param {Array<import('../../metadata/types').MetadataEntry>} params.datas - Per-page metadata, in render order.
  * @param {Array<{ data: import('../../metadata/types').MetadataEntry }>} params.sidebarEntries - Entries used to build the sidebar page list (real module pages only).
  * @param {string} params.template - The HTML template string for the output pages.
+ * @param {boolean} params.searchEnabled - Whether to render the search control.
  */
 export async function processBundles({
   serverCodeMap,
@@ -164,11 +165,12 @@ export async function processBundles({
   datas,
   sidebarEntries,
   template,
+  searchEnabled,
 }) {
   const config = getConfig('web');
   const requireFn = createRequire(import.meta.url);
   const virtualImports = {
-    '#theme/config': createConfigSource(sidebarEntries),
+    '#theme/config': createConfigSource(sidebarEntries, searchEnabled),
     ...config.virtualImports,
   };
 


### PR DESCRIPTION
## Description

Only render the web documentation search control when `orama-db` is one of the requested generator targets. This avoids showing a search UI that cannot return results when users generate only the `web` output.

The generator orchestration context now supplies the requested targets without making the web config source read the full run configuration. The web generator derives a build-time `searchEnabled` flag and supports an explicit `web.showSearchBar` override for deployments that provide search data separately. The navigation conditionally renders `SearchBox`, with regression coverage for both `web`-only and `web` + `orama-db` generation.

A patch changeset is included because this changes published web-generator behavior.

## Validation

- `node --test --experimental-test-module-mocks src/generators/web/__tests__/generate.test.mjs` (Node.js 24.18.0)
- `node --run test` — 514 tests passed (Node.js 24.18.0)
- `node --run lint` — no errors; 2 pre-existing warnings in `useOrama.mjs`
- `node --run format:check`
- `git diff --check`

## Related Issues

Fixes #891

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
