### PR TITLE
Render web search only when enabled

### DIFF
--- a/src/generators/web/README.md
+++ b/src/generators/web/README.md
@@ -13,6 +13,7 @@ The `web` generator accepts the following configuration options:
 | `project`         | `string`  | `'Node.js'`                                   | Project name used in page titles and the version selector                                                   |
 | `title`           | `string`  | `'{project} v{version} Documentation'`        | Title template for HTML pages (supports `{project}`, `{version}`)                                           |
 | `useAbsoluteURLs` | `boolean` | `false`                                       | When `true`, all internal links use absolute URLs based on `baseURL`                                        |
+| `showSearchBar`   | `boolean` | Whether `orama-db` is targeted                | Explicitly show or hide the navigation search bar                                                           |
 | `editURL`         | `string`  | `'${GITHUB_EDIT_URL}/doc/api{path}.md'`       | URL template for "edit this page" links                                                                     |
 | `pageURL`         | `string`  | `'{baseURL}/latest-{version}/api{path}.html'` | URL template for documentation page links                                                                   |
 | `remoteConfigUrl` | `string`  | `'https://nodejs.org/site.json'`              | URL fetched client-side at runtime for remote site config (currently used to power the announcement banner) |

--- a/src/generators/web/__tests__/generate.test.mjs
+++ b/src/generators/web/__tests__/generate.test.mjs
@@ -45,6 +45,19 @@ const createEntry = (api, name) => {
 };
 
 describe('web generate', () => {
+  it('renders the search bar only when it is enabled', async () => {
+    const config = await setConfig({ target: ['web'] });
+    const fs = createEntry('fs', 'File system');
+    const input = [toCodeItem(await buildContent([fs], fs))];
+
+    const [withoutSearch] = await generate(input);
+    assert.doesNotMatch(withoutSearch.html, /Start typing/);
+
+    config.web.showSearchBar = true;
+    const [withSearch] = await generate(input);
+    assert.match(withSearch.html, /Start typing/);
+  });
+
   it('omits View As links for synthetic pages only', async () => {
     await setConfig({});
 

--- a/src/generators/web/types.d.ts
+++ b/src/generators/web/types.d.ts
@@ -31,6 +31,7 @@ export type Configuration = {
   templatePath: string;
   title: string;
   useAbsoluteURLs: boolean;
+  showSearchBar?: boolean;
   head: HeadConfig;
   // Options spread into LightningCSS while bundling CSS. `filename`, `code`,
   // `cssModules`, and `resolver` are managed by the generator and ignored here.

--- a/src/generators/web/ui/components/NavBar.jsx
+++ b/src/generators/web/ui/components/NavBar.jsx
@@ -6,7 +6,7 @@ import GitHubIcon from '@node-core/ui-components/Icons/Social/GitHub';
 import SearchBox from './SearchBox';
 import { useTheme } from '../hooks/useTheme.mjs';
 
-import { repository } from '#theme/config';
+import { repository, showSearchBar } from '#theme/config';
 import Logo from '#theme/Logo';
 
 /**
@@ -21,7 +21,7 @@ export default ({ metadata }) => {
       sidebarItemTogglerAriaLabel="Toggle navigation menu"
       navItems={[]}
     >
-      <SearchBox pathname={metadata.path} />
+      {showSearchBar && <SearchBox pathname={metadata.path} />}
       <ThemeToggle
         onChange={setThemePreference}
         currentTheme={themePreference}

--- a/src/generators/web/ui/types.d.ts
+++ b/src/generators/web/ui/types.d.ts
@@ -22,6 +22,7 @@ declare module '#theme/config' {
   export const templatePath: Configuration['templatePath'];
   export const title: Configuration['title'];
   export const useAbsoluteURLs: Configuration['useAbsoluteURLs'];
+  export const showSearchBar: boolean;
 
   // From config generation
   export const version: SemVer;

--- a/src/utils/configuration/__tests__/index.test.mjs
+++ b/src/utils/configuration/__tests__/index.test.mjs
@@ -18,6 +18,7 @@ mock.module('../../../generators/index.mjs', {
       json: { defaultConfiguration: { format: 'json' } },
       html: { defaultConfiguration: { format: 'html' } },
       markdown: {},
+      web: { defaultConfiguration: {} },
     },
   },
 });
@@ -230,6 +231,36 @@ describe('config.mjs', () => {
       assert.ok(config.json);
       assert.ok(config.html);
       assert.ok(config.markdown);
+    });
+
+    it('should show web search by default only when orama-db is targeted', async () => {
+      const withOrama = await createRunConfiguration({
+        target: ['web', 'orama-db'],
+      });
+      assert.strictEqual(withOrama.web.showSearchBar, true);
+
+      const withoutOrama = await createRunConfiguration({ target: ['web'] });
+      assert.strictEqual(withoutOrama.web.showSearchBar, false);
+    });
+
+    it('should preserve explicit web search visibility overrides', async () => {
+      mockImportFromURL.mock.mockImplementationOnce(async () =>
+        createMockConfig({ web: { showSearchBar: true } })
+      );
+      const forcedOn = await createRunConfiguration({
+        configFile: 'config.mjs',
+        target: ['web'],
+      });
+      assert.strictEqual(forcedOn.web.showSearchBar, true);
+
+      mockImportFromURL.mock.mockImplementationOnce(async () =>
+        createMockConfig({ web: { showSearchBar: false } })
+      );
+      const forcedOff = await createRunConfiguration({
+        configFile: 'config.mjs',
+        target: ['web', 'orama-db'],
+      });
+      assert.strictEqual(forcedOff.web.showSearchBar, false);
     });
   });
 

--- a/src/utils/configuration/index.mjs
+++ b/src/utils/configuration/index.mjs
@@ -133,6 +133,7 @@ export const assertRunnableOptions = config => {
 export const createRunConfiguration = async options => {
   const config = await loadConfigFile(options.configFile);
   config.target &&= enforceArray(config.target);
+  const configuredShowSearchBar = config.web?.showSearchBar;
 
   // Merge with defaults
   const merged = deepMerge(
@@ -140,6 +141,11 @@ export const createRunConfiguration = async options => {
     createConfigFromCLIOptions(options),
     getDefaultConfig()
   );
+
+  // Search is available by default when the pipeline builds an Orama database,
+  // while an explicit web-generator option can force it on or off.
+  merged.web.showSearchBar =
+    configuredShowSearchBar ?? enforceArray(merged.target).includes('orama-db');
 
   // These need to be coerced
   merged.threads = Math.max(merged.threads, 1);


### PR DESCRIPTION
## Summary

- derive the web generator's `showSearchBar` setting from whether `orama-db` is targeted
- preserve explicit `showSearchBar: true` and `showSearchBar: false` overrides
- conditionally render the navigation search UI
- document and type the new option
- cover both configuration behavior and generated HTML

## Why

The web navigation always rendered its search control, even when the generator pipeline did not build an Orama database. In that configuration the control was visible but could not return results.

The resolved configuration now enables search automatically when `orama-db` is part of the target list. Projects that share a remote database or intentionally hide search can still override the derived default explicitly.

## Validation

- `node --test --experimental-test-module-mocks "src/**/*.test.mjs"` (516 tests passed)
- `eslint . --no-warn-ignored` (0 errors; 2 existing warnings in `useOrama.mjs`)
- `prettier --check .`

Closes #891
