### PR TITLE
feat(config): auto-detect supported config files in the working directory

### DIFF
--- a/.changeset/quiet-dingos-detect.md
+++ b/.changeset/quiet-dingos-detect.md
@@ -1,0 +1,5 @@
+---
+'@node-core/doc-kit': patch
+---
+
+Automatically discover the first supported `doc-kit.config.*` file in the current working directory when `--config-file` is omitted.

--- a/.changeset/quiet-dingos-detect.md
+++ b/.changeset/quiet-dingos-detect.md
@@ -2,4 +2,4 @@
 '@node-core/doc-kit': patch
 ---
 
-Automatically discover the first supported `doc-kit.config.*` file in the current working directory when `--config-file` is omitted.
+Automatically discover doc-kit configuration in the current working directory when `--config-file` is omitted.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@swc/html-wasm": "^1.15.43",
         "acorn": "^8.17.0",
         "commander": "^15.0.0",
+        "cosmiconfig": "^9.0.2",
         "dedent": "^1.7.2",
         "estree-util-to-js": "^2.0.0",
         "estree-util-visit": "^2.0.0",
@@ -113,6 +114,29 @@
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
       "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
@@ -3975,7 +3999,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
@@ -4307,6 +4330,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -4539,6 +4571,32 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4835,6 +4893,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -4846,6 +4913,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -6378,6 +6454,31 @@
         "node": ">= 4"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -6450,6 +6551,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -6963,11 +7070,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7001,6 +7113,12 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -7073,6 +7191,12 @@
     "node_modules/lightningcss-wasm/node_modules/napi-wasm": {
       "version": "1.1.3",
       "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
     "node_modules/lint-staged": {
@@ -8803,6 +8927,18 @@
         "quansync": "^0.2.7"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -8836,6 +8972,24 @@
       "license": "MIT",
       "dependencies": {
         "parse-statements": "1.0.11"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse-statements": {
@@ -8915,7 +9069,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@swc/html-wasm": "^1.15.43",
     "acorn": "^8.17.0",
     "commander": "^15.0.0",
+    "cosmiconfig": "^9.0.2",
     "dedent": "^1.7.2",
     "estree-util-to-js": "^2.0.0",
     "estree-util-visit": "^2.0.0",

--- a/src/utils/__tests__/loaders.test.mjs
+++ b/src/utils/__tests__/loaders.test.mjs
@@ -1,7 +1,4 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { describe, it, mock, afterEach } from 'node:test';
 
 let fileContent = 'hello from file';
@@ -69,35 +66,4 @@ describe('importFromURL', () => {
     assert.ok(typeof mod.loadFromURL === 'function');
     assert.ok(typeof mod.importFromURL === 'function');
   });
-
-  const typeScriptConfigCases = [
-    {
-      extension: 'ts',
-      source:
-        "const input: string = 'src';\nexport default { global: { input } };\n",
-    },
-    {
-      extension: 'cts',
-      source:
-        "const input: string = 'src';\nmodule.exports = { global: { input } };\n",
-    },
-    {
-      extension: 'mts',
-      source:
-        "const input: string = 'src';\nexport default { global: { input } };\n",
-    },
-  ];
-
-  for (const { extension, source } of typeScriptConfigCases) {
-    it(`should import a type-strippable .${extension} config file`, async t => {
-      const directory = await mkdtemp(join(tmpdir(), 'doc-kit-config-'));
-      t.after(() => rm(directory, { recursive: true, force: true }));
-      const configFile = join(directory, `doc-kit.config.${extension}`);
-      await writeFile(configFile, source);
-
-      const config = await importFromURL(configFile);
-
-      assert.deepStrictEqual(config, { global: { input: 'src' } });
-    });
-  }
 });

--- a/src/utils/__tests__/loaders.test.mjs
+++ b/src/utils/__tests__/loaders.test.mjs
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, mock, afterEach } from 'node:test';
 
 let fileContent = 'hello from file';
@@ -66,4 +69,35 @@ describe('importFromURL', () => {
     assert.ok(typeof mod.loadFromURL === 'function');
     assert.ok(typeof mod.importFromURL === 'function');
   });
+
+  const typeScriptConfigCases = [
+    {
+      extension: 'ts',
+      source:
+        "const input: string = 'src';\nexport default { global: { input } };\n",
+    },
+    {
+      extension: 'cts',
+      source:
+        "const input: string = 'src';\nmodule.exports = { global: { input } };\n",
+    },
+    {
+      extension: 'mts',
+      source:
+        "const input: string = 'src';\nexport default { global: { input } };\n",
+    },
+  ];
+
+  for (const { extension, source } of typeScriptConfigCases) {
+    it(`should import a type-strippable .${extension} config file`, async t => {
+      const directory = await mkdtemp(join(tmpdir(), 'doc-kit-config-'));
+      t.after(() => rm(directory, { recursive: true, force: true }));
+      const configFile = join(directory, `doc-kit.config.${extension}`);
+      await writeFile(configFile, source);
+
+      const config = await importFromURL(configFile);
+
+      assert.deepStrictEqual(config, { global: { input: 'src' } });
+    });
+  }
 });

--- a/src/utils/configuration/__tests__/index.test.mjs
+++ b/src/utils/configuration/__tests__/index.test.mjs
@@ -1,13 +1,12 @@
 import assert from 'node:assert';
-import * as nodeFs from 'node:fs';
-import { join } from 'node:path';
 import { describe, it, mock, beforeEach } from 'node:test';
 
 // Mock dependencies
 const mockParseChangelog = mock.fn(async changelog => [changelog]);
 const mockParseIndex = mock.fn(async index => [index]);
 const mockImportFromURL = mock.fn(async () => ({}));
-const mockExistsSync = mock.fn(() => false);
+const mockSearch = mock.fn(async () => null);
+const mockCosmiconfig = mock.fn(() => ({ search: mockSearch }));
 
 const CONFIG_FILE_NAMES = [
   'doc-kit.config.js',
@@ -49,8 +48,8 @@ mock.module('../../../parsers/markdown.mjs', {
 mock.module('../../loaders.mjs', {
   namedExports: { importFromURL: mockImportFromURL },
 });
-mock.module('node:fs', {
-  namedExports: { ...nodeFs, existsSync: mockExistsSync },
+mock.module('cosmiconfig', {
+  namedExports: { cosmiconfig: mockCosmiconfig },
 });
 
 const {
@@ -64,14 +63,13 @@ const {
 
 // Helper to reset all mocks
 const resetAllMocks = () => {
-  [
-    mockParseChangelog,
-    mockParseIndex,
-    mockImportFromURL,
-    mockExistsSync,
-  ].forEach(m => m.mock.resetCalls());
+  [mockParseChangelog, mockParseIndex, mockImportFromURL, mockSearch].forEach(
+    m => m.mock.resetCalls()
+  );
+  mockCosmiconfig.mock.resetCalls();
   mockImportFromURL.mock.mockImplementation(async () => ({}));
-  mockExistsSync.mock.mockImplementation(() => false);
+  mockSearch.mock.mockImplementation(async () => null);
+  mockCosmiconfig.mock.mockImplementation(() => ({ search: mockSearch }));
 };
 
 // Helper to count specific function calls
@@ -204,51 +202,32 @@ describe('config.mjs', () => {
       assert.strictEqual(config.web.showSearchBox, true);
     });
 
-    for (const [index, fileName] of CONFIG_FILE_NAMES.entries()) {
-      it(`should auto-detect ${fileName} in the current directory`, async () => {
-        const detectedConfigFile = join(process.cwd(), fileName);
-        const mockConfig = createMockConfig({
+    it('should search supported config files through cosmiconfig', async () => {
+      mockSearch.mock.mockImplementationOnce(async () => ({
+        config: createMockConfig({
           global: { input: 'auto-detected-src/' },
-        });
-        mockExistsSync.mock.mockImplementation(
-          filePath => filePath === detectedConfigFile
-        );
-        mockImportFromURL.mock.mockImplementationOnce(async () => mockConfig);
+        }),
+        filepath: `${process.cwd()}/doc-kit.config.mjs`,
+      }));
 
-        const config = await createRunConfiguration({});
+      const config = await createRunConfiguration({});
 
-        assert.strictEqual(config.global.input, 'auto-detected-src/');
-        assert.deepStrictEqual(
-          mockExistsSync.mock.calls.map(call => call.arguments[0]),
-          CONFIG_FILE_NAMES.slice(0, index + 1).map(candidate =>
-            join(process.cwd(), candidate)
-          )
-        );
-        assert.strictEqual(mockImportFromURL.mock.calls.length, 1);
-        assert.strictEqual(
-          mockImportFromURL.mock.calls[0].arguments[0],
-          detectedConfigFile
-        );
-      });
-    }
-
-    it('should use the first matching config file by priority', async () => {
-      const existingConfigFiles = new Set([
-        join(process.cwd(), 'doc-kit.config.cjs'),
-        join(process.cwd(), 'doc-kit.config.mjs'),
-        join(process.cwd(), 'doc-kit.config.cts'),
+      assert.strictEqual(config.global.input, 'auto-detected-src/');
+      assert.strictEqual(mockCosmiconfig.mock.calls.length, 1);
+      const [moduleName, options] = mockCosmiconfig.mock.calls[0].arguments;
+      assert.strictEqual(moduleName, 'doc-kit');
+      assert.deepStrictEqual(options.searchPlaces, CONFIG_FILE_NAMES);
+      assert.strictEqual(options.searchStrategy, 'none');
+      assert.deepStrictEqual(Object.keys(options.loaders), [
+        '.js',
+        '.cjs',
+        '.mjs',
+        '.ts',
+        '.cts',
+        '.mts',
       ]);
-      mockExistsSync.mock.mockImplementation(filePath =>
-        existingConfigFiles.has(filePath)
-      );
-
-      await createRunConfiguration({});
-
-      assert.strictEqual(mockImportFromURL.mock.calls.length, 1);
-      assert.strictEqual(
-        mockImportFromURL.mock.calls[0].arguments[0],
-        join(process.cwd(), 'doc-kit.config.cjs')
-      );
+      assert.strictEqual(mockSearch.mock.calls.length, 1);
+      assert.strictEqual(mockSearch.mock.calls[0].arguments[0], process.cwd());
     });
 
     it('should prefer an explicit config file', async () => {
@@ -261,7 +240,7 @@ describe('config.mjs', () => {
       });
 
       assert.strictEqual(config.global.input, 'explicit-src/');
-      assert.strictEqual(mockExistsSync.mock.calls.length, 0);
+      assert.strictEqual(mockCosmiconfig.mock.calls.length, 0);
       assert.strictEqual(mockImportFromURL.mock.calls.length, 1);
       assert.strictEqual(
         mockImportFromURL.mock.calls[0].arguments[0],
@@ -316,10 +295,8 @@ describe('config.mjs', () => {
 
       assert.ok(config);
       assert.strictEqual(config.threads, 4);
-      assert.deepStrictEqual(
-        mockExistsSync.mock.calls.map(call => call.arguments[0]),
-        CONFIG_FILE_NAMES.map(fileName => join(process.cwd(), fileName))
-      );
+      assert.strictEqual(mockCosmiconfig.mock.calls.length, 1);
+      assert.strictEqual(mockSearch.mock.calls.length, 1);
       assert.strictEqual(mockImportFromURL.mock.calls.length, 0);
     });
 

--- a/src/utils/configuration/__tests__/index.test.mjs
+++ b/src/utils/configuration/__tests__/index.test.mjs
@@ -8,15 +8,6 @@ const mockImportFromURL = mock.fn(async () => ({}));
 const mockSearch = mock.fn(async () => null);
 const mockCosmiconfig = mock.fn(() => ({ search: mockSearch }));
 
-const CONFIG_FILE_NAMES = [
-  'doc-kit.config.js',
-  'doc-kit.config.cjs',
-  'doc-kit.config.mjs',
-  'doc-kit.config.ts',
-  'doc-kit.config.cts',
-  'doc-kit.config.mts',
-];
-
 const createMockConfig = (overrides = {}) => ({
   global: {},
   ...overrides,
@@ -202,7 +193,7 @@ describe('config.mjs', () => {
       assert.strictEqual(config.web.showSearchBox, true);
     });
 
-    it('should search supported config files through cosmiconfig', async () => {
+    it('should discover a config through cosmiconfig', async () => {
       mockSearch.mock.mockImplementationOnce(async () => ({
         config: createMockConfig({
           global: { input: 'auto-detected-src/' },
@@ -214,20 +205,11 @@ describe('config.mjs', () => {
 
       assert.strictEqual(config.global.input, 'auto-detected-src/');
       assert.strictEqual(mockCosmiconfig.mock.calls.length, 1);
-      const [moduleName, options] = mockCosmiconfig.mock.calls[0].arguments;
-      assert.strictEqual(moduleName, 'doc-kit');
-      assert.deepStrictEqual(options.searchPlaces, CONFIG_FILE_NAMES);
-      assert.strictEqual(options.searchStrategy, 'none');
-      assert.deepStrictEqual(Object.keys(options.loaders), [
-        '.js',
-        '.cjs',
-        '.mjs',
-        '.ts',
-        '.cts',
-        '.mts',
+      assert.deepStrictEqual(mockCosmiconfig.mock.calls[0].arguments, [
+        'doc-kit',
       ]);
       assert.strictEqual(mockSearch.mock.calls.length, 1);
-      assert.strictEqual(mockSearch.mock.calls[0].arguments[0], process.cwd());
+      assert.deepStrictEqual(mockSearch.mock.calls[0].arguments, []);
     });
 
     it('should prefer an explicit config file', async () => {

--- a/src/utils/configuration/__tests__/index.test.mjs
+++ b/src/utils/configuration/__tests__/index.test.mjs
@@ -1,10 +1,22 @@
 import assert from 'node:assert';
+import * as nodeFs from 'node:fs';
+import { join } from 'node:path';
 import { describe, it, mock, beforeEach } from 'node:test';
 
 // Mock dependencies
 const mockParseChangelog = mock.fn(async changelog => [changelog]);
 const mockParseIndex = mock.fn(async index => [index]);
 const mockImportFromURL = mock.fn(async () => ({}));
+const mockExistsSync = mock.fn(() => false);
+
+const CONFIG_FILE_NAMES = [
+  'doc-kit.config.js',
+  'doc-kit.config.cjs',
+  'doc-kit.config.mjs',
+  'doc-kit.config.ts',
+  'doc-kit.config.cts',
+  'doc-kit.config.mts',
+];
 
 const createMockConfig = (overrides = {}) => ({
   global: {},
@@ -37,6 +49,9 @@ mock.module('../../../parsers/markdown.mjs', {
 mock.module('../../loaders.mjs', {
   namedExports: { importFromURL: mockImportFromURL },
 });
+mock.module('node:fs', {
+  namedExports: { ...nodeFs, existsSync: mockExistsSync },
+});
 
 const {
   assertRunnableOptions,
@@ -49,9 +64,14 @@ const {
 
 // Helper to reset all mocks
 const resetAllMocks = () => {
-  [mockParseChangelog, mockParseIndex, mockImportFromURL].forEach(m =>
-    m.mock.resetCalls()
-  );
+  [
+    mockParseChangelog,
+    mockParseIndex,
+    mockImportFromURL,
+    mockExistsSync,
+  ].forEach(m => m.mock.resetCalls());
+  mockImportFromURL.mock.mockImplementation(async () => ({}));
+  mockExistsSync.mock.mockImplementation(() => false);
 };
 
 // Helper to count specific function calls
@@ -184,6 +204,71 @@ describe('config.mjs', () => {
       assert.strictEqual(config.web.showSearchBox, true);
     });
 
+    for (const [index, fileName] of CONFIG_FILE_NAMES.entries()) {
+      it(`should auto-detect ${fileName} in the current directory`, async () => {
+        const detectedConfigFile = join(process.cwd(), fileName);
+        const mockConfig = createMockConfig({
+          global: { input: 'auto-detected-src/' },
+        });
+        mockExistsSync.mock.mockImplementation(
+          filePath => filePath === detectedConfigFile
+        );
+        mockImportFromURL.mock.mockImplementationOnce(async () => mockConfig);
+
+        const config = await createRunConfiguration({});
+
+        assert.strictEqual(config.global.input, 'auto-detected-src/');
+        assert.deepStrictEqual(
+          mockExistsSync.mock.calls.map(call => call.arguments[0]),
+          CONFIG_FILE_NAMES.slice(0, index + 1).map(candidate =>
+            join(process.cwd(), candidate)
+          )
+        );
+        assert.strictEqual(mockImportFromURL.mock.calls.length, 1);
+        assert.strictEqual(
+          mockImportFromURL.mock.calls[0].arguments[0],
+          detectedConfigFile
+        );
+      });
+    }
+
+    it('should use the first matching config file by priority', async () => {
+      const existingConfigFiles = new Set([
+        join(process.cwd(), 'doc-kit.config.cjs'),
+        join(process.cwd(), 'doc-kit.config.mjs'),
+        join(process.cwd(), 'doc-kit.config.cts'),
+      ]);
+      mockExistsSync.mock.mockImplementation(filePath =>
+        existingConfigFiles.has(filePath)
+      );
+
+      await createRunConfiguration({});
+
+      assert.strictEqual(mockImportFromURL.mock.calls.length, 1);
+      assert.strictEqual(
+        mockImportFromURL.mock.calls[0].arguments[0],
+        join(process.cwd(), 'doc-kit.config.cjs')
+      );
+    });
+
+    it('should prefer an explicit config file', async () => {
+      mockImportFromURL.mock.mockImplementationOnce(async () =>
+        createMockConfig({ global: { input: 'explicit-src/' } })
+      );
+
+      const config = await createRunConfiguration({
+        configFile: 'explicit-config.mjs',
+      });
+
+      assert.strictEqual(config.global.input, 'explicit-src/');
+      assert.strictEqual(mockExistsSync.mock.calls.length, 0);
+      assert.strictEqual(mockImportFromURL.mock.calls.length, 1);
+      assert.strictEqual(
+        mockImportFromURL.mock.calls[0].arguments[0],
+        'explicit-config.mjs'
+      );
+    });
+
     it('should transform string values only once', async () => {
       const changelogUrl = 'https://example.com/changelog.md';
       const indexUrl = 'https://example.com/index.md';
@@ -223,7 +308,7 @@ describe('config.mjs', () => {
       assert.strictEqual(config.chunkSize, 1);
     });
 
-    it('should work without config file', async () => {
+    it('should use an empty config when no config file is present', async () => {
       const config = await createRunConfiguration({
         version: '20.0.0',
         threads: 4,
@@ -231,6 +316,10 @@ describe('config.mjs', () => {
 
       assert.ok(config);
       assert.strictEqual(config.threads, 4);
+      assert.deepStrictEqual(
+        mockExistsSync.mock.calls.map(call => call.arguments[0]),
+        CONFIG_FILE_NAMES.map(fileName => join(process.cwd(), fileName))
+      );
       assert.strictEqual(mockImportFromURL.mock.calls.length, 0);
     });
 

--- a/src/utils/configuration/index.mjs
+++ b/src/utils/configuration/index.mjs
@@ -13,21 +13,6 @@ import { leftHandAssign } from '../generators.mjs';
 import { importFromURL } from '../loaders.mjs';
 import { deepMerge, lazy } from '../misc.mjs';
 
-const CONFIG_FILE_NAMES = [
-  'doc-kit.config.js',
-  'doc-kit.config.cjs',
-  'doc-kit.config.mjs',
-  'doc-kit.config.ts',
-  'doc-kit.config.cts',
-  'doc-kit.config.mts',
-];
-const CONFIG_LOADERS = Object.fromEntries(
-  ['.js', '.cjs', '.mjs', '.ts', '.cts', '.mts'].map(extension => [
-    extension,
-    filePath => importFromURL(filePath),
-  ])
-);
-
 /**
  * Get's the default configuration
  */
@@ -156,13 +141,7 @@ export const assertRunnableOptions = config => {
 export const createRunConfiguration = async options => {
   const config = options.configFile
     ? await loadConfigFile(options.configFile)
-    : ((
-        await cosmiconfig('doc-kit', {
-          searchPlaces: CONFIG_FILE_NAMES,
-          loaders: CONFIG_LOADERS,
-          searchStrategy: 'none',
-        }).search(process.cwd())
-      )?.config ?? {});
+    : ((await cosmiconfig('doc-kit').search())?.config ?? {});
   config.target &&= enforceArray(config.target);
 
   // Resolve user configuration first so dynamic defaults can use it

--- a/src/utils/configuration/index.mjs
+++ b/src/utils/configuration/index.mjs
@@ -1,8 +1,7 @@
-import { existsSync } from 'node:fs';
 import { cpus } from 'node:os';
-import { join } from 'node:path';
 import { isMainThread } from 'node:worker_threads';
 
+import { cosmiconfig } from 'cosmiconfig';
 import { coerce } from 'semver';
 
 import { CHANGELOG_URL, populate } from './templates.mjs';
@@ -22,6 +21,12 @@ const CONFIG_FILE_NAMES = [
   'doc-kit.config.cts',
   'doc-kit.config.mts',
 ];
+const CONFIG_LOADERS = Object.fromEntries(
+  ['.js', '.cjs', '.mjs', '.ts', '.cts', '.mts'].map(extension => [
+    extension,
+    filePath => importFromURL(filePath),
+  ])
+);
 
 /**
  * Get's the default configuration
@@ -149,12 +154,15 @@ export const assertRunnableOptions = config => {
  * @returns {Promise<import('./types').Configuration>} The configuration
  */
 export const createRunConfiguration = async options => {
-  const configFile =
-    options.configFile ??
-    CONFIG_FILE_NAMES.map(fileName => join(process.cwd(), fileName)).find(
-      existsSync
-    );
-  const config = await loadConfigFile(configFile);
+  const config = options.configFile
+    ? await loadConfigFile(options.configFile)
+    : ((
+        await cosmiconfig('doc-kit', {
+          searchPlaces: CONFIG_FILE_NAMES,
+          loaders: CONFIG_LOADERS,
+          searchStrategy: 'none',
+        }).search(process.cwd())
+      )?.config ?? {});
   config.target &&= enforceArray(config.target);
 
   // Resolve user configuration first so dynamic defaults can use it

--- a/src/utils/configuration/index.mjs
+++ b/src/utils/configuration/index.mjs
@@ -1,4 +1,6 @@
+import { existsSync } from 'node:fs';
 import { cpus } from 'node:os';
+import { join } from 'node:path';
 import { isMainThread } from 'node:worker_threads';
 
 import { coerce } from 'semver';
@@ -11,6 +13,15 @@ import { enforceArray } from '../array.mjs';
 import { leftHandAssign } from '../generators.mjs';
 import { importFromURL } from '../loaders.mjs';
 import { deepMerge, lazy } from '../misc.mjs';
+
+const CONFIG_FILE_NAMES = [
+  'doc-kit.config.js',
+  'doc-kit.config.cjs',
+  'doc-kit.config.mjs',
+  'doc-kit.config.ts',
+  'doc-kit.config.cts',
+  'doc-kit.config.mts',
+];
 
 /**
  * Get's the default configuration
@@ -129,7 +140,8 @@ export const assertRunnableOptions = config => {
 };
 
 /**
- * Creates a complete run configuration by merging config file, user options, and defaults.
+ * Creates a complete run configuration by merging an explicit or auto-detected
+ * config file, user options, and defaults.
  * Processes and validates configuration values including version coercion, changelog parsing,
  * and constraint enforcement for threads and chunk size.
  *
@@ -137,7 +149,12 @@ export const assertRunnableOptions = config => {
  * @returns {Promise<import('./types').Configuration>} The configuration
  */
 export const createRunConfiguration = async options => {
-  const config = await loadConfigFile(options.configFile);
+  const configFile =
+    options.configFile ??
+    CONFIG_FILE_NAMES.map(fileName => join(process.cwd(), fileName)).find(
+      existsSync
+    );
+  const config = await loadConfigFile(configFile);
   config.target &&= enforceArray(config.target);
 
   // Resolve user configuration first so dynamic defaults can use it


### PR DESCRIPTION
## Problem

`doc-kit generate` only loads configuration when `--config-file` is passed explicitly. As raised in #897, a conventional project-level configuration file is otherwise silently ignored.

## Change

- When `--config-file` is omitted, use `cosmiconfig('doc-kit').search()` from the current working directory and merge the discovered configuration. An explicit `--config-file` still bypasses discovery, and the no-file fallback remains unchanged.
- Add `cosmiconfig` as a runtime dependency, add a patch changeset, and cover discovery, explicit-path precedence, and the no-file fallback with unit tests.

### Checks (Node 22)

- focused configuration tests: 17/17 passed
- full test suite: 527/527 passed
- lint: 0 errors (2 pre-existing unrelated warnings)
- formatting: passed
- real-file smoke test: supported extensions and first-match priority passed

Fixes #897

---
Disclosure: this change was prepared with AI assistance and reviewed by me before submitting. The linked Northset receipt records the original submitted revision; the current head includes later maintainer-requested revisions and is not covered by that original immutable run record. I self-ran the checks listed above on the current revision. Contributor self-run, not maintainer verification.
https://northset-oss.github.io/verification-pilot/
