### PR TITLE
fix: update monospace font-face for fenced code block

### DIFF
--- a/src/generators/web/ui/index.css
+++ b/src/generators/web/ui/index.css
@@ -16,6 +16,27 @@ main {
     word-break: break-word;
   }
 
+  /*
+   * Fenced code blocks use a system monospace stack instead of IBM Plex Mono.
+   * Plex has no glyphs for the Unicode Box Drawing block (U+2500–U+257F) and
+   * Google Fonts never serves that block, so the box-drawing characters in
+   * ASCII-art diagrams (e.g. the URL table in url.md) fall back per-glyph to
+   * the OS default monospace. On Windows that is Consolas (0.55em) while Plex
+   * letters are 0.60em; the mismatched advance widths shear the diagram out of
+   * alignment. Rendering the whole block in one system font keeps every glyph
+   * the same width — the same stack nodejs.org and the legacy-html generator
+   * already use. See https://github.com/nodejs/doc-kit/issues/909.
+   *
+   * This only overrides the variable within `pre`, so inline code and the rest
+   * of the UI keep IBM Plex Mono. The variable keeps its name because the
+   * compiled @node-core/ui-components CSS reads `var(--font-ibm-plex-mono)`.
+   */
+  pre {
+    --font-ibm-plex-mono:
+      'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', 'Courier New',
+      monospace;
+  }
+
   /* Don't overflow the parent */
   .overflow-container {
     overflow-x: auto;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds a font-stack for pre / code blocks.

I _heavily used_ Claude Code Opus to measure glphs and understand the problem, the fix is quite easy and surgical, suggested by me.

## Validation

Watch the preview

https://api-docs-tooling-git-windows-table-openjs.vercel.app/url.html

<img width="1804" height="1071" alt="image" src="https://github.com/user-attachments/assets/b95723fc-c9fe-4178-8a45-866473a22485" />



## Related Issues

Possible fix for #909

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
