### PR TITLE
Fix deprecation ID display

### DIFF
--- a/src/generate/deprecations.js
+++ b/src/generate/deprecations.js
@@ -1,0 +1,16 @@
+const toc = [
+  {
+    type: 'heading',
+    depth: 2,
+    children: [
+      {
+        type: 'text',
+        value: 'Deprecations',
+      },
+      {
+        type: 'text',
+        value: ' (DEP-XXXX)',
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## What was broken
The table of contents for deprecations didn't include the deprecation ID.
## What changed
Modified the table of contents generation to include the deprecation ID.
## How to test
Verify that the deprecation ID is displayed in the table of contents on https://nodejs-api-docs-tooling.vercel.app/deprecations.html