### PR TITLE
fix: preserve deprecation codes in table of contents

### DIFF
--- a/.changeset/tidy-deprecations-smile.md
+++ b/.changeset/tidy-deprecations-smile.md
@@ -1,0 +1,5 @@
+---
+'@node-core/doc-kit': patch
+---
+
+Preserve deprecation codes in generated table-of-contents labels.

--- a/src/generators/jsx-ast/utils/__tests__/buildBarProps.test.mjs
+++ b/src/generators/jsx-ast/utils/__tests__/buildBarProps.test.mjs
@@ -116,6 +116,28 @@ describe('extractHeadings', () => {
     assert.equal(result[1].value, 'new Buffer');
   });
 
+  it('preserves deprecation codes in heading labels', () => {
+    const entries = [
+      {
+        heading: {
+          depth: 2,
+          data: {
+            text: 'DEP0001: `http.OutgoingMessage.prototype.flush`',
+            name: 'http.OutgoingMessage.prototype.flush',
+            slug: 'DEP0001',
+          },
+        },
+      },
+    ];
+
+    const result = extractHeadings(entries);
+
+    assert.equal(
+      result[0].value,
+      'DEP0001: http.OutgoingMessage.prototype.flush'
+    );
+  });
+
   it('drops overload headings and links to the first signature', () => {
     const entries = [
       {

--- a/src/generators/jsx-ast/utils/buildBarProps.mjs
+++ b/src/generators/jsx-ast/utils/buildBarProps.mjs
@@ -9,9 +9,6 @@ import { TOC_MAX_HEADING_DEPTH } from '../constants.mjs';
 // rather than the full signature.
 const FUNCTION_HEADING_TYPES = new Set(['method', 'ctor', 'classMethod']);
 
-// Deprecation codes are part of the heading label, not a generic type prefix.
-const DEPRECATION_HEADING_REGEX = /^DEP\d+:/;
-
 /**
  * Generate a combined plain text string from all MDAST entries for estimating reading time.
  *
@@ -59,16 +56,13 @@ const headingLabel = data => {
     return cliFlagOrEnv.at(-1)[1];
   }
 
-  if (DEPRECATION_HEADING_REGEX.test(data.text)) {
-    return data.text.replace(/`/g, '').trim();
-  }
-
   return (
     data.text
       // Remove any containing code blocks
       .replace(/`/g, '')
-      // Remove any prefixes (i.e. 'Class:')
-      .replace(/^[^:]+:/, '')
+      // Remove any prefixes (i.e. 'Class:'), except deprecation codes
+      // (i.e. 'DEP0001:') which are part of the label
+      .replace(/^(?!DEP\d+:)[^:]+:/, '')
       // Trim the remaining whitespace
       .trim()
   );

--- a/src/generators/jsx-ast/utils/buildBarProps.mjs
+++ b/src/generators/jsx-ast/utils/buildBarProps.mjs
@@ -9,6 +9,9 @@ import { TOC_MAX_HEADING_DEPTH } from '../constants.mjs';
 // rather than the full signature.
 const FUNCTION_HEADING_TYPES = new Set(['method', 'ctor', 'classMethod']);
 
+// Deprecation codes are part of the heading label, not a generic type prefix.
+const DEPRECATION_HEADING_REGEX = /^DEP\d+:/;
+
 /**
  * Generate a combined plain text string from all MDAST entries for estimating reading time.
  *
@@ -54,6 +57,10 @@ const headingLabel = data => {
 
   if (cliFlagOrEnv.length > 0) {
     return cliFlagOrEnv.at(-1)[1];
+  }
+
+  if (DEPRECATION_HEADING_REGEX.test(data.text)) {
+    return data.text.replace(/`/g, '').trim();
   }
 
   return (


### PR DESCRIPTION
## Description

On the deprecations page, sidebar/ToC labels are built by `headingLabel` in `src/generators/jsx-ast/utils/buildBarProps.mjs`, which strips any leading `<something>:` prefix (meant for prefixes like `Class:`). That rule also strips deprecation codes, so `DEP0001: http.OutgoingMessage.prototype.flush` renders in the ToC as just `http.OutgoingMessage.prototype.flush`, making it hard to locate a deprecation by its ID.

This PR adds a narrow exception: headings matching `DEP\d+:` keep their full text (backticks removed) as the label, so the deprecation code shows up in the ToC — matching the behavior of the legacy nodejs.org deprecations page.

## Validation

- New unit test in `src/generators/jsx-ast/utils/__tests__/buildBarProps.test.mjs`: `DEP0001: \`http.OutgoingMessage.prototype.flush\`` now yields the label `DEP0001: http.OutgoingMessage.prototype.flush`.
- `node --run test` — 523 tests pass, 0 fail.
- `node --run lint` — no errors (2 pre-existing warnings in `src/generators/web/ui/hooks/useOrama.mjs`, untouched by this PR).
- `node --run format:check` — clean.

## Related Issues

Fixes #917

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
