### PR TITLE
perf: fix render-blocking CSS and font display

### DIFF
--- a/src/generators/legacy-html/template.html
+++ b/src/generators/legacy-html/template.html
@@ -7,10 +7,32 @@
     <meta name="nodejs.org:node-version" content="__VERSION__" />
     <title>__SECTION__ | Node.js __VERSION__ Documentation</title>
     <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Lato:400,700,400italic&display=fallback"
+      rel="preload"
+      href="https://fonts.googleapis.com/css?family=Lato:400,700,400italic&display=swap"
+      as="style"
+      onload="
+        this.onload = null;
+        this.rel = 'stylesheet';
+      "
     />
-    <link rel="stylesheet" href="assets/style.css" />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css?family=Lato:400,700,400italic&display=swap"
+      />
+    </noscript>
+    <link
+      rel="preload"
+      href="assets/style.css"
+      as="style"
+      onload="
+        this.onload = null;
+        this.rel = 'stylesheet';
+      "
+    />
+    <noscript>
+      <link rel="stylesheet" href="assets/style.css" />
+    </noscript>
     <link rel="canonical" href="https://nodejs.org/api/__FILENAME__.html" />
     <script async defer src="assets/api.js" type="text/javascript"></script>
     <script>

--- a/src/generators/web/template.html
+++ b/src/generators/web/template.html
@@ -5,7 +5,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>${title}</title>
-  <link rel="stylesheet" href="${root}styles.css" />
+  <link rel="preload" href="${root}styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+    <link rel="stylesheet" href="${root}styles.css">
+  </noscript>
   <meta property="og:title" content="${title}">
   <meta property="og:type" content="website">
 
@@ -13,8 +16,10 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet"
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=Open+Sans:ital,wght@0,300..800;1,300..800" />
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" />
+  </noscript>
 
   <!-- Apply theme before paint to avoid Flash of Unstyled Content -->
   <script>${themeScript}</script>


### PR DESCRIPTION
## Description

As shown in the attached Lighthouse performance reports, the generated HTML templates have Render-Blocking issues caused by the main `styles.css` and the Google Fonts CSS files. Furthermore, the Google Fonts lacked display=swap, causing a Flash of Invisible Text (FOIT).

<img width="720" height="372" alt="image" src="https://github.com/user-attachments/assets/d4efbff7-def9-4b27-95c9-651ace880847" />

<img width="720" height="238" alt="image" src="https://github.com/user-attachments/assets/cd764102-6b01-4a5a-876f-214919fbc826" />


This PR improves performance (both web and legacy) by:

- Implementing a high-performance `rel="preload"` pattern: that instructs the browser to download the file with low priority. The `onload` script flips the attribute back to stylesheet once downloading is complete, applying the styles smoothly.

- Using `display=swap` on Google Fonts to ensure text is immediately visible with the default text till the font is downloaded, then apply that.

## Validation

Tested on `webpack/webpack-doc-kit`.

**Before:**
<img width="720" height="370" alt="image" src="https://github.com/user-attachments/assets/1bb24939-077a-457b-a236-d868b769fb41" />

**After:**
<img width="720" height="370" alt="image" src="https://github.com/user-attachments/assets/90ebbd61-4a4b-47e0-bb58-2464fb48cc48" />


## Related Issues

None

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `node --run test` and all tests passed.
- [X] I have check code formatting with `node --run format` & `node --run lint`.
- [X] I've covered new added functionality with unit tests if necessary.
