### PR TITLE
chore: stop versioning generators

### DIFF
--- a/docs/generators.md
+++ b/docs/generators.md
@@ -83,8 +83,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'my-format',
 
-  version: '1.0.0',
-
   description: 'Generates documentation in MyFormat',
 
   // This generator depends on the metadata generator
@@ -189,8 +187,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'parallel-generator',
 
-  version: '1.0.0',
-
   description: 'Processes data in parallel',
 
   dependsOn: 'metadata',
@@ -285,8 +281,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'streaming-generator',
 
-  version: '1.0.0',
-
   description: 'Streams results as they are ready',
 
   dependsOn: 'metadata',
@@ -344,8 +338,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
  */
 export default createLazyGenerator({
   name: 'batch-generator',
-
-  version: '1.0.0',
 
   description: 'Requires all input at once',
 

--- a/src/generators/__tests__/index.test.mjs
+++ b/src/generators/__tests__/index.test.mjs
@@ -1,8 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import semver from 'semver';
-
 import { allGenerators } from '../index.mjs';
 
 const validDependencies = Object.keys(allGenerators);
@@ -16,16 +14,6 @@ describe('All Generators', () => {
         key,
         generator.name,
         `Generator key "${key}" does not match its name property "${generator.name}"`
-      );
-    });
-  });
-
-  it('should have valid semver versions', () => {
-    allGeneratorsEntries.forEach(([key, generator]) => {
-      const isValid = semver.valid(generator.version);
-      assert.ok(
-        isValid,
-        `Generator "${key}" has invalid semver version: "${generator.version}"`
       );
     });
   });

--- a/src/generators/addon-verify/index.mjs
+++ b/src/generators/addon-verify/index.mjs
@@ -12,8 +12,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default await createLazyGenerator({
   name: 'addon-verify',
 
-  version: '1.0.0',
-
   description:
     'Generates a file list from code blocks extracted from `doc/api/addons.md` to facilitate C++ compilation and JavaScript runtime validations',
 

--- a/src/generators/api-links/index.mjs
+++ b/src/generators/api-links/index.mjs
@@ -16,8 +16,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'api-links',
 
-  version: '1.0.0',
-
   description:
     'Creates a mapping of publicly accessible functions to their source locations in the Node.js repository.',
 

--- a/src/generators/ast-js/index.mjs
+++ b/src/generators/ast-js/index.mjs
@@ -15,8 +15,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'ast-js',
 
-  version: '1.0.0',
-
   description: 'Parses Javascript source files passed into the input.',
 
   hasParallelProcessor: true,

--- a/src/generators/ast/index.mjs
+++ b/src/generators/ast/index.mjs
@@ -11,8 +11,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'ast',
 
-  version: '1.0.0',
-
   description: 'Parses Markdown API doc files into AST trees',
 
   hasParallelProcessor: true,

--- a/src/generators/json-simple/index.mjs
+++ b/src/generators/json-simple/index.mjs
@@ -14,8 +14,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'json-simple',
 
-  version: '1.0.0',
-
   description:
     'Generates the simple JSON version of the API docs, and returns it as a string',
 

--- a/src/generators/jsx-ast/index.mjs
+++ b/src/generators/jsx-ast/index.mjs
@@ -10,8 +10,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'jsx-ast',
 
-  version: '1.0.0',
-
   description: 'Generates JSX AST from the input MDAST',
 
   dependsOn: 'metadata',

--- a/src/generators/legacy-html-all/index.mjs
+++ b/src/generators/legacy-html-all/index.mjs
@@ -15,8 +15,6 @@ import legacyHtml from '../legacy-html/index.mjs';
 export default createLazyGenerator({
   name: 'legacy-html-all',
 
-  version: '1.0.0',
-
   description:
     'Generates the `all.html` file from the `legacy-html` generator, which includes all the modules in one single file',
 

--- a/src/generators/legacy-html/index.mjs
+++ b/src/generators/legacy-html/index.mjs
@@ -18,8 +18,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'legacy-html',
 
-  version: '1.0.0',
-
   description:
     'Generates the legacy version of the API docs in HTML, with the assets and styles included as files',
 

--- a/src/generators/legacy-json-all/index.mjs
+++ b/src/generators/legacy-json-all/index.mjs
@@ -11,8 +11,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'legacy-json-all',
 
-  version: '1.0.0',
-
   description:
     'Generates the `all.json` file from the `legacy-json` generator, which includes all the modules in one single file.',
 

--- a/src/generators/legacy-json/index.mjs
+++ b/src/generators/legacy-json/index.mjs
@@ -16,8 +16,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'legacy-json',
 
-  version: '1.0.0',
-
   description: 'Generates the legacy version of the JSON API docs.',
 
   dependsOn: 'metadata',

--- a/src/generators/llms-txt/index.mjs
+++ b/src/generators/llms-txt/index.mjs
@@ -13,8 +13,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'llms-txt',
 
-  version: '1.0.0',
-
   description:
     'Generates a llms.txt file to provide information to LLMs at inference time',
 

--- a/src/generators/man-page/index.mjs
+++ b/src/generators/man-page/index.mjs
@@ -13,8 +13,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'man-page',
 
-  version: '1.0.0',
-
   description: 'Generates the Node.js man-page.',
 
   dependsOn: 'metadata',

--- a/src/generators/metadata/index.mjs
+++ b/src/generators/metadata/index.mjs
@@ -10,8 +10,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'metadata',
 
-  version: '1.0.0',
-
   description: 'generates a flattened list of API doc metadata entries',
 
   dependsOn: 'ast',

--- a/src/generators/orama-db/index.mjs
+++ b/src/generators/orama-db/index.mjs
@@ -11,8 +11,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'orama-db',
 
-  version: '1.0.0',
-
   description: 'Generates the Orama database for the API docs.',
 
   dependsOn: 'metadata',

--- a/src/generators/sitemap/index.mjs
+++ b/src/generators/sitemap/index.mjs
@@ -10,8 +10,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'sitemap',
 
-  version: '1.0.0',
-
   description: 'Generates a sitemap.xml file for search engine optimization',
 
   dependsOn: 'metadata',

--- a/src/generators/types.d.ts
+++ b/src/generators/types.d.ts
@@ -65,8 +65,6 @@ declare global {
     // The name of the Generator. Must match the Key in AllGenerators
     name: keyof AllGenerators;
 
-    version: string;
-
     description: string;
 
     hasParallelProcessor: boolean;

--- a/src/generators/web/index.mjs
+++ b/src/generators/web/index.mjs
@@ -24,8 +24,6 @@ import { createLazyGenerator } from '../../utils/generators.mjs';
 export default createLazyGenerator({
   name: 'web',
 
-  version: '1.0.0',
-
   description: 'Generates HTML/CSS/JS bundles from JSX AST entries',
 
   dependsOn: 'jsx-ast',

--- a/src/utils/__tests__/generators.test.mjs
+++ b/src/utils/__tests__/generators.test.mjs
@@ -129,10 +129,14 @@ describe('createLazyGenerator', () => {
   afterEach(() => mock.restoreAll());
 
   it('spreads metadata properties onto the returned object', () => {
-    const metadata = { name: 'ast', version: '1.0.0', dependsOn: undefined };
+    const metadata = {
+      name: 'ast',
+      description: 'Parses Markdown',
+      dependsOn: undefined,
+    };
     const gen = createLazyGenerator(metadata);
     assert.equal(gen.name, 'ast');
-    assert.equal(gen.version, '1.0.0');
+    assert.equal(gen.description, 'Parses Markdown');
   });
 
   it('exposes generate and processChunk functions that delegate to the lazily loaded module', async () => {


### PR DESCRIPTION
consumers should refer to the main doc-kit version