### PR TITLE
fix(type-annotations): space union separators in type values

### DIFF
--- a/.changeset/spaced-union-types.md
+++ b/.changeset/spaced-union-types.md
@@ -1,0 +1,5 @@
+---
+'@node-core/doc-kit': patch
+---
+
+Space union separators in type annotation values (`{string|URL}` is now rendered as `string | URL`).

--- a/src/utils/type-annotations/__tests__/remark.test.mjs
+++ b/src/utils/type-annotations/__tests__/remark.test.mjs
@@ -28,8 +28,18 @@ describe('remarkTypeAnnotations', () => {
   it('parses multiple annotations in one paragraph', () => {
     assert.deepEqual(valuesIn('{string} and {Buffer|Blob} and {integer}'), [
       'string',
-      'Buffer|Blob',
+      'Buffer | Blob',
       'integer',
+    ]);
+  });
+
+  it('spaces union separators, without touching `||`', () => {
+    assert.deepEqual(valuesIn('Takes {string|URL} or {string  |  URL}.'), [
+      'string | URL',
+      'string | URL',
+    ]);
+    assert.deepEqual(valuesIn("Defaults to {req.url || '/'}."), [
+      "req.url || '/'",
     ]);
   });
 
@@ -62,7 +72,7 @@ describe('remarkTypeAnnotations', () => {
       '| `flag` | {string\\|number} |',
     ].join('\n');
 
-    assert.deepEqual(valuesIn(markdown), ['string|number']);
+    assert.deepEqual(valuesIn(markdown), ['string | number']);
   });
 
   it('normalizes interior line breaks to spaces', () => {
@@ -122,6 +132,6 @@ describe('remarkTypeAnnotations', () => {
       processor.parse('Returns: {Promise<Buffer|string>} on success.')
     );
 
-    assert.match(output, /\{Promise<Buffer\|string>\}/);
+    assert.match(output, /\{Promise<Buffer \| string>\}/);
   });
 });

--- a/src/utils/type-annotations/mdast.mjs
+++ b/src/utils/type-annotations/mdast.mjs
@@ -5,6 +5,10 @@
 // and the mandatory `\|` inside GFM table cells must be decoded here.
 const CHARACTER_ESCAPE = /\\([!-/:-@[-`{-~])/g;
 
+// A single union separator, with any surrounding whitespace. Lookarounds
+// exclude `||` (logical OR in default-value prose).
+const UNION_SEPARATOR = /(?<!\|)\s*\|\s*(?!\|)/g;
+
 /**
  * Creates the mdast-util-from-markdown extension that compiles
  * `typeAnnotation` tokens into `{ type: 'typeAnnotation', value }` nodes.
@@ -48,7 +52,7 @@ export const typeAnnotationFromMarkdown = () => ({
         .replace(/\s+/g, ' ')
         .trim()
         .replace(CHARACTER_ESCAPE, '$1')
-        .replace(/(?<!\|)\s*\|\s*(?!\|)/g, ' | ');
+        .replace(UNION_SEPARATOR, ' | ');
 
       this.exit(token);
     },

--- a/src/utils/type-annotations/mdast.mjs
+++ b/src/utils/type-annotations/mdast.mjs
@@ -10,7 +10,8 @@ const CHARACTER_ESCAPE = /\\([!-/:-@[-`{-~])/g;
  * `typeAnnotation` tokens into `{ type: 'typeAnnotation', value }` nodes.
  *
  * The stored `value` is the canonical, single-line, unescaped TypeScript type
- * text; link offsets computed later are relative to it.
+ * text with union separators spaced (`A | B`); link offsets computed later
+ * are relative to it.
  *
  * @returns {import('mdast-util-from-markdown').Extension}
  */
@@ -46,7 +47,8 @@ export const typeAnnotationFromMarkdown = () => ({
       node.value = node.value
         .replace(/\s+/g, ' ')
         .trim()
-        .replace(CHARACTER_ESCAPE, '$1');
+        .replace(CHARACTER_ESCAPE, '$1')
+        .replace(/(?<!\|)\s*\|\s*(?!\|)/g, ' | ');
 
       this.exit(token);
     },


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
In the documentation, parameter descriptions should be similar to parameter types in the code, with spaces between multiple types and the `|` identifier for a more consistent look.

|old | new|
|---|---|
|<img width="1044" height="540" alt="image" src="https://github.com/user-attachments/assets/9de05b1b-5bf1-48d5-9812-fe88f235668f" />|<img width="1036" height="551" alt="image" src="https://github.com/user-attachments/assets/9819a6d7-ca20-45b0-ac6c-299ea25da71e" />|

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
