### PR TITLE
fix: do not render headings with no content

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -117,7 +117,7 @@ reproduce literal output.
 A conforming [document][term-document] MUST contain elements in the following
 order. Items marked OPTIONAL MAY be omitted entirely.
 
-1. **Title heading** (OPTIONAL) - An [ATX heading][cm-atx-heading] at depth 1.
+1. **Title heading** (OPTIONAL, RECOMMENDED) - An [ATX heading][cm-atx-heading] at depth 1.
 2. **[Simple directives][§6.2]** (OPTIONAL) - Zero or more
    [HTML comment][cm-html-comment] directives providing
    [document][term-document]-level metadata. These MUST immediately follow
@@ -173,7 +173,7 @@ NOT be used.
 
 #### 4.2.1. Depth 1
 
-The [document][term-document] title. Exactly one depth-1 heading MUST appear
+The [document][term-document] title. Exactly one depth-1 heading SHOULD appear
 per document.
 
 #### 4.2.2. Depth 2

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -117,8 +117,7 @@ reproduce literal output.
 A conforming [document][term-document] MUST contain elements in the following
 order. Items marked OPTIONAL MAY be omitted entirely.
 
-1. **Title heading** (REQUIRED) - Exactly one [ATX heading][cm-atx-heading]
-   at depth 1.
+1. **Title heading** (OPTIONAL) - An [ATX heading][cm-atx-heading] at depth 1.
 2. **[Simple directives][§6.2]** (OPTIONAL) - Zero or more
    [HTML comment][cm-html-comment] directives providing
    [document][term-document]-level metadata. These MUST immediately follow

--- a/packages/core/src/generators/metadata/utils/parse.mjs
+++ b/packages/core/src/generators/metadata/utils/parse.mjs
@@ -87,7 +87,7 @@ export const parseApiDoc = ({ path, tree, mdx = false }, typeMap) => {
   // Handles the normalisation URLs that reference to API doc files with .md extension
   visit(tree, UNIST.isMarkdownUrl, node => visitMarkdownLink(node));
 
-  // If the document has no headings but it has content, we add a fake heading to the top
+  // If the document has no headings but it has content, we add a fake heading to the top, it will not be rendered
   if (headingNodes.length === 0 && tree.children.length > 0) {
     tree.children.unshift(createTree('heading', { depth: 1 }, []));
   }

--- a/packages/react/src/jsx-ast/utils/buildContent.mjs
+++ b/packages/react/src/jsx-ast/utils/buildContent.mjs
@@ -151,6 +151,11 @@ export const extractHeadingContent = content => {
  * @param {import('unist').Node|null} changeElement - The change history element, if available
  */
 export const createHeadingElement = (content, changeElement) => {
+  // If the heading is empty, we don't render it
+  if (!content.children || content.children.length === 0) {
+    return { type: 'text', value: '' };
+  }
+
   const { type, slug } = content.data;
 
   let headingContent = extractHeadingContent(content);


### PR DESCRIPTION
## Description

Currently, if an MDX page lacks an ATX H1 (e.g., when the `h1` is built into a custom React component), `doc-kit` automatically injects an empty `h1` to satisfy AST structural requirements and metadata generation.
 
However, this leads to an issue for MDX: if it renders its own custom `h1` in a React component, the final HTML ends up with **two `h1` tags** (one from `doc-kit`, one from the component), breaking SEO and Accessibility.

 The current workaround involves forcing a `# Heading` in markdown and visually hiding it via CSS (`sr-only`), which is a hack.
 
This PR still injects an empty `h1`, but it doesn't render the empty headings in general to DOM.

## Validation

Tested on `webpack-doc-kit`:

**Before:**
<img width="463" height="261" alt="image" src="https://github.com/user-attachments/assets/2b1eea9d-3e6d-492c-982a-35366d1a5c99" />

**After:**
<img width="463" height="180" alt="image" src="https://github.com/user-attachments/assets/627fa152-ec08-4221-961c-84a7a9112c35" />

## Related Issues

None

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `node --run test` and all tests passed.
- [X] I have check code formatting with `node --run format` & `node --run lint`.
- [X] I've covered new added functionality with unit tests if necessary.
