### PR TITLE
fix(config): add missing spaces in riscv64 threads warning

### DIFF
--- a/.changeset/riscv64-warning-spacing.md
+++ b/.changeset/riscv64-warning-spacing.md
@@ -1,0 +1,6 @@
+---
+'@node-core/doc-kit': patch
+---
+
+Fix missing spaces in the riscv64 multithreading warning message, which
+previously concatenated as "failures whenallocating" and "spaceon riscv64".

--- a/src/utils/configuration/index.mjs
+++ b/src/utils/configuration/index.mjs
@@ -158,8 +158,8 @@ export const createRunConfiguration = async options => {
 
   if (process.arch === 'riscv64' && merged.threads > 1) {
     logger.warn(
-      `Using ${merged.threads} threads might cause failures when` +
-        'allocating wasm memory due to insufficient virtual address space' +
+      `Using ${merged.threads} threads might cause failures when ` +
+        'allocating wasm memory due to insufficient virtual address space ' +
         'on riscv64 with sv39. Please consider using only a single thread.'
     );
   }


### PR DESCRIPTION
The warning shown when running with multiple threads on riscv64 concatenated its string parts without trailing spaces, producing `failures whenallocating` and `address spaceon riscv64`.

This adds the missing spaces so the message reads correctly.