### PR TITLE
fix(metadata): reset `lastIndex` of unix manual page regex before testing

### DIFF
--- a/.changeset/unix-manual-regex-lastindex.md
+++ b/.changeset/unix-manual-regex-lastindex.md
@@ -1,0 +1,7 @@
+---
+'@node-core/doc-kit': patch
+---
+
+Fix `isTextWithUnixManual` intermittently missing valid Unix manual page
+references: the shared `unixManualPage` regex is global, so its `lastIndex`
+persisted between `.test()` calls during tree traversal.

--- a/src/utils/queries/index.mjs
+++ b/src/utils/queries/index.mjs
@@ -41,8 +41,10 @@ export const UNIST = {
    * @param {import('@types/mdast').Text} text
    * @returns {boolean}
    */
-  isTextWithUnixManual: ({ type, value }) =>
-    type === 'text' && QUERIES.unixManualPage.test(value),
+  isTextWithUnixManual: ({ type, value }) => {
+    QUERIES.unixManualPage.lastIndex = 0; // Reset the lastIndex to ensure proper matching
+    return type === 'text' && QUERIES.unixManualPage.test(value);
+  },
 
   /**
    * @param {import('@types/mdast').Link} link


### PR DESCRIPTION
`QUERIES.unixManualPage` is a global regex (`/g`), so its `lastIndex` persists between calls. `UNIST.isTextWithUnixManual` uses `.test()` on this shared instance while visiting text nodes: after a successful match, the next `.test()` starts from the end of the previous match, intermittently returning `false` for text that does contain a Unix manual page reference.

This resets `lastIndex` to 0 before each test so every node is matched from the start.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test#:~:text=They%20store%20a%20lastIndex%20from%20the%20previous%20match.%20Using%20this%20internally%2C%20test()%20can%20be%20used%20to%20iterate%20over%20multiple%20matches%20in%20a%20string%20of%20text%20(with%20capture%20groups).