### PR TITLE
refactor(generators): use `Map.groupBy` in `groupNodesByModule`

### DIFF
--- a/src/utils/generators.mjs
+++ b/src/utils/generators.mjs
@@ -11,18 +11,7 @@ import { lazy } from './misc.mjs';
  * @param {Array<import('../generators/metadata/types').MetadataEntry>} nodes The API metadata Nodes to be grouped
  */
 export const groupNodesByModule = nodes => {
-  /** @type {Map<string, Array<import('../generators/metadata/types').MetadataEntry>>} */
-  const groupedNodes = new Map();
-
-  for (const node of nodes) {
-    if (!groupedNodes.has(node.api)) {
-      groupedNodes.set(node.api, []);
-    }
-
-    groupedNodes.get(node.api).push(node);
-  }
-
-  return groupedNodes;
+  return Map.groupBy(nodes, node => node.api);
 };
 
 /**


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Replaces the hand-rolled Map grouping loop in groupNodesByModule with the native Map.groupBy() static method. It groups an iterable by the value returned from a callback, which is semantically identical to the previous implementation — a behavior-neutral simplification that reduces boilerplate and improves readability.                                                   

`Map.groupBy()` requires Node.js ≥ 21 (V8 12.0); the project's .nvmrc pins Node 24, so this is safe.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy
<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
