### PR TITLE
chore: remove redundant `format` script

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,5 +27,5 @@ You can check the items by adding an `x` between the brackets, like this: `[x]`
 
 - [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
 - [ ] I have run `node --run test` and all tests passed.
-- [ ] I have check code formatting with `node --run format` & `node --run lint`.
+- [ ] I have check code formatting with `node --run format:check` & `node --run lint`.
 - [ ] I've covered new added functionality with unit tests if necessary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ The steps below will give you a general idea of how to prepare your local enviro
 5. **Check code quality**
 
    ```bash
-   node --run format
+   node --run format:check
    node --run lint
    ```
 
@@ -317,7 +317,7 @@ This project uses automated code quality tools:
 
 ```bash
 # Format code
-node --run format # To apply changes, use `format:write`
+node --run format:write # To only check formatting, use `format:check`
 
 # Lint code
 node --run lint # To apply changes, use `lint:fix`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,7 +317,7 @@ This project uses automated code quality tools:
 
 ```bash
 # Format code
-node --run format:write # To only check formatting, use `format:check`
+node --run format # To only check formatting, use `format:check`
 
 # Lint code
 node --run lint # To apply changes, use `lint:fix`

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "lint": "eslint . --no-warn-ignored",
     "lint:fix": "eslint --fix . --no-warn-ignored",
-    "format": "prettier .",
     "format:write": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "node --test --experimental-test-module-mocks \"src/**/*.test.mjs\"",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint . --no-warn-ignored",
     "lint:fix": "eslint --fix . --no-warn-ignored",
-    "format:write": "prettier --write .",
+    "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "node --test --experimental-test-module-mocks \"src/**/*.test.mjs\"",
     "test:coverage": "c8 node --test --experimental-test-module-mocks \"src/**/*.test.mjs\"",


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
The bare `prettier .` invocation only prints formatted file contents to stdout without modifying or checking anything. Direct contributors to `format:write` and `format:check` instead, and update CONTRIBUTING.md and the pull request template accordingly.
<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
