### PR TITLE
fix: sync URL hash when following same-page search hits

### DIFF
--- a/.changeset/tidy-donuts-search.md
+++ b/.changeset/tidy-donuts-search.md
@@ -1,0 +1,5 @@
+---
+'@node-core/doc-kit': patch
+---
+
+Sync the URL hash when following same-page search hits

--- a/packages/core/src/generators/web/ui/components/SearchBox/index.jsx
+++ b/packages/core/src/generators/web/ui/components/SearchBox/index.jsx
@@ -21,7 +21,7 @@ const followSearchHit = event => {
     return;
   }
 
-  const target = new URL(event.currentTarget.href);
+  const { href } = event.currentTarget;
 
   event.preventDefault();
 
@@ -30,22 +30,16 @@ const followSearchHit = event => {
     new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
   );
 
-  requestAnimationFrame(() => {
-    if (target.pathname !== window.location.pathname) {
-      window.location.href = target.href;
-      return;
-    }
-
+  // A plain `location.href` assignment covers both cases: same-page hits
+  // become a native fragment navigation (hash, scroll and history entry
+  // included), cross-page hits simply load the target page. The nested
+  // `requestAnimationFrame` waits for the modal to actually close —
+  // navigating while it is still open suppresses the fragment scroll.
+  requestAnimationFrame(() =>
     requestAnimationFrame(() => {
-      // Keep the URL hash in sync with the followed hit, since
-      // `scrollIntoView` alone leaves the previous hash untouched.
-      history.pushState(null, '', target.hash || target.pathname);
-
-      document
-        .getElementById(decodeURIComponent(target.hash.slice(1)))
-        ?.scrollIntoView();
-    });
-  });
+      window.location.href = href;
+    })
+  );
 };
 
 /**

--- a/packages/core/src/generators/web/ui/components/SearchBox/index.jsx
+++ b/packages/core/src/generators/web/ui/components/SearchBox/index.jsx
@@ -36,11 +36,15 @@ const followSearchHit = event => {
       return;
     }
 
-    requestAnimationFrame(() =>
+    requestAnimationFrame(() => {
+      // Keep the URL hash in sync with the followed hit, since
+      // `scrollIntoView` alone leaves the previous hash untouched.
+      history.pushState(null, '', target.hash || target.pathname);
+
       document
         .getElementById(decodeURIComponent(target.hash.slice(1)))
-        ?.scrollIntoView()
-    );
+        ?.scrollIntoView();
+    });
   });
 };
 


### PR DESCRIPTION
`followSearchHit` only called `scrollIntoView()` for same-page hits, leaving the address bar without a hash (or stuck on a stale one from a previously followed hit). Push the hit's hash via `history.pushState` before scrolling so the URL always reflects the jumped-to anchor.

rel https://github.com/nodejs/doc-kit/pull/955#discussion_r3686930346 cc @avivkeller 
<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format:check` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
