### PR TITLE
feat(web): make the top navigation bar sticky

### DIFF
--- a/.changeset/sticky-navigation-bar.md
+++ b/.changeset/sticky-navigation-bar.md
@@ -1,0 +1,5 @@
+---
+'@node-core/doc-kit': minor
+---
+
+Make the web top navigation bar sticky while scrolling, and offset the sticky meta bar, anchor scrolling, and Radix popups so they are not covered by it

--- a/packages/core/src/generators/web/ui/components/MetaBar/index.jsx
+++ b/packages/core/src/generators/web/ui/components/MetaBar/index.jsx
@@ -62,6 +62,9 @@ export default ({ metadata, headings = [], readingTime }) => {
   return (
     <MetaBar
       heading="Table of Contents"
+      // Offset the sticky position by the sticky navigation bar's height,
+      // otherwise the navigation bar covers the top of the meta bar
+      style={{ top: 'var(--header-height)' }}
       headings={{
         items: headings.map(({ value, stability, ...heading }) => ({
           ...heading,

--- a/packages/core/src/generators/web/ui/components/MetaBar/index.jsx
+++ b/packages/core/src/generators/web/ui/components/MetaBar/index.jsx
@@ -63,8 +63,10 @@ export default ({ metadata, headings = [], readingTime }) => {
     <MetaBar
       heading="Table of Contents"
       // Offset the sticky position by the sticky navigation bar's height,
-      // otherwise the navigation bar covers the top of the meta bar
-      style={{ top: 'var(--header-height)' }}
+      // otherwise the navigation bar covers the top of the meta bar.
+      // `--header-height` comes from `@node-core/ui-components` base styles;
+      // fall back to its current value (4rem) in case it is ever renamed
+      style={{ top: 'var(--header-height, 4rem)' }}
       headings={{
         items: headings.map(({ value, stability, ...heading }) => ({
           ...heading,

--- a/packages/core/src/generators/web/ui/components/NavBar.jsx
+++ b/packages/core/src/generators/web/ui/components/NavBar.jsx
@@ -16,23 +16,25 @@ export default ({ metadata }) => {
   const [themePreference, setThemePreference] = useTheme();
 
   return (
-    <NavBar
-      Logo={Logo}
-      sidebarItemTogglerAriaLabel="Toggle navigation menu"
-      navItems={[]}
-    >
-      {showSearchBox && <SearchBox pathname={metadata.path} />}
-      <ThemeToggle
-        onChange={setThemePreference}
-        currentTheme={themePreference}
-      />
-      <a
-        href={`https://github.com/${repository}`}
-        aria-label={`View ${repository} on GitHub`}
-        className={styles.ghIconWrapper}
+    <div className="nav-bar-sticky">
+      <NavBar
+        Logo={Logo}
+        sidebarItemTogglerAriaLabel="Toggle navigation menu"
+        navItems={[]}
       >
-        <GitHubIcon />
-      </a>
-    </NavBar>
+        {showSearchBox && <SearchBox pathname={metadata.path} />}
+        <ThemeToggle
+          onChange={setThemePreference}
+          currentTheme={themePreference}
+        />
+        <a
+          href={`https://github.com/${repository}`}
+          aria-label={`View ${repository} on GitHub`}
+          className={styles.ghIconWrapper}
+        >
+          <GitHubIcon />
+        </a>
+      </NavBar>
+    </div>
   );
 };

--- a/packages/core/src/generators/web/ui/index.css
+++ b/packages/core/src/generators/web/ui/index.css
@@ -10,6 +10,25 @@
   --font-ibm-plex-mono: 'IBM Plex Mono', monospace;
 }
 
+/* Keep the top navigation bar visible while scrolling */
+.nav-bar-sticky {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+}
+
+/* Radix popups (theme switcher, selects) must paint above the sticky
+   navigation bar; they render in a portal and slightly overlap the bar.
+   `!important` is needed because Radix sets an inline `z-index: auto` */
+[data-radix-popper-content-wrapper] {
+  z-index: 50 !important;
+}
+
+/* Keep anchored headings below the sticky navigation bar */
+main [id] {
+  scroll-margin-top: calc(var(--header-height, 4rem) + 1rem);
+}
+
 main {
   /* Code should inherit its font size */
   code {

--- a/packages/core/src/generators/web/ui/index.css
+++ b/packages/core/src/generators/web/ui/index.css
@@ -10,11 +10,14 @@
   --font-ibm-plex-mono: 'IBM Plex Mono', monospace;
 }
 
-/* Keep the top navigation bar visible while scrolling */
+/* Keep the top navigation bar visible while scrolling. The hidden sidebar
+   toggler checkbox inside the NavBar is translated above the bar, so clip it:
+   inside this stacking context it would otherwise cover the banner above */
 .nav-bar-sticky {
   position: sticky;
   top: 0;
   z-index: 40;
+  overflow: hidden;
 }
 
 /* Radix popups (theme switcher, selects) must paint above the sticky


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Keep the logo, search box, and theme toggle visible while scrolling.
- Wrap NavBar in a sticky container (z-index 40)
- Offset the sticky meta bar by --header-height so it is not covered
- Add scroll-margin-top to anchored headings below the sticky bar
- Raise Radix popups above the bar (z-index 50, overrides inline style)

It allows you to quickly search for information anywhere on the page without having to scroll to the top.
<details>
<img width="1667" height="649" alt="image" src="https://github.com/user-attachments/assets/883aa74a-eb3a-476a-bec9-99cdc3c3d17c" />
</details>
<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format:check` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
