### PR TITLE
fix(core): add tsconfig so global generator types resolve

### DIFF
--- a/packages/core/src/generators/metadata/types.d.ts
+++ b/packages/core/src/generators/metadata/types.d.ts
@@ -1,4 +1,5 @@
-import type { Root, Position, Node, Data, Blockquote, Heading } from 'mdast';
+import type { Position } from 'unist';
+import type { Root, Node, Data, Blockquote, Heading } from 'mdast';
 
 export type Generator = GeneratorMetadata<
   {},

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Without a tsconfig, the editor's inferred project never included generators/types.d.ts, so the global GeneratorMetadata/Generate/ ProcessChunk types were unresolved in every generator's types.d.ts (reported at orama-db/types.d.ts:27).

Also fix the Position import in metadata/types.d.ts: @types/mdast v4 no longer exports it, so import it from unist instead. Explicitly set "types": ["node"] since TypeScript 6.0 defaults types to [].

<img width="1750" height="636" alt="image" src="https://github.com/user-attachments/assets/79c45fdb-0130-425a-9a26-a1135984ee07" />


<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format:check` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
