### PR TITLE
fix: move tsconfig.json to project root

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "types": ["node"],
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["packages/*/src"]
 }


### PR DESCRIPTION
The packages/core/tsconfig.json only covered packages/core/src, leaving packages/react and packages/node-legacy without a TypeScript project context. This caused type errors in their types.d.ts files that reference global types (GeneratorMetadata, Generate, ProcessChunk) declared in packages/core/src/generators/types.d.ts.

A root tsconfig.json with include: ["packages/*/src"] ensures all packages share a single compilation context where the global type declarations are visible everywhere.

<img width="1318" height="344" alt="image" src="https://github.com/user-attachments/assets/d8bc3825-cd04-4066-a33b-0594c05598e4" />

<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format:check` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
