### PR TITLE
fix: resolve `[object Object]` in ChangeHistory aria-label and dropdown scrolbar

### DIFF
--- a/.changeset/change-history-label-and-scrollbar.md
+++ b/.changeset/change-history-label-and-scrollbar.md
@@ -1,0 +1,12 @@
+---
+'@doc-kit/generator-react': patch
+---
+
+Fix `[object Object]` in ChangeHistory aria-label and dropdown horizontal scrollbar
+
+- Change history labels were passing a JSX AST object instead of a plain text
+  string to the `ChangeHistory` component, causing `aria-label` to render as
+  `[object Object]`. Labels are now extracted as plain text via `remark-parse`.
+- The ChangeHistory dropdown could show a horizontal scrollbar when label text
+  overflowed the fixed-width container. Added `overflow-wrap` and `word-break`
+  rules to prevent this.

--- a/packages/react/src/html/ui/index.css
+++ b/packages/react/src/html/ui/index.css
@@ -121,6 +121,12 @@ main {
       div[role='menu'] {
         left: 0;
       }
+
+      /* Prevent long labels from overflowing dropdown width */
+      div[role='menu'] > a[role='menuitem'] > div {
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
     }
   }
 

--- a/packages/react/src/html/ui/index.css
+++ b/packages/react/src/html/ui/index.css
@@ -120,12 +120,12 @@ main {
 
       div[role='menu'] {
         left: 0;
-      }
 
-      /* Prevent long labels from overflowing dropdown width */
-      div[role='menu'] > a[role='menuitem'] > div {
-        overflow-wrap: anywhere;
-        word-break: break-word;
+        /* Prevent long labels from overflowing dropdown width */
+        a[role='menuitem'] div{
+          overflow-wrap: anywhere;
+          word-break: break-word;
+        }
       }
     }
   }

--- a/packages/react/src/html/ui/index.css
+++ b/packages/react/src/html/ui/index.css
@@ -122,7 +122,7 @@ main {
         left: 0;
 
         /* Prevent long labels from overflowing dropdown width */
-        a[role='menuitem'] div{
+        a[role='menuitem'] div {
           overflow-wrap: anywhere;
           word-break: break-word;
         }

--- a/packages/react/src/jsx-ast/utils/__tests__/buildContent.test.mjs
+++ b/packages/react/src/jsx-ast/utils/__tests__/buildContent.test.mjs
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test';
 
 import { setConfig } from '@doc-kit/core/utils/configuration/index.mjs';
 
-import { transformHeadingNode } from '../buildContent.mjs';
+import { transformHeadingNode, gatherChangeEntries } from '../buildContent.mjs';
 
 const heading = {
   type: 'heading',
@@ -65,5 +65,80 @@ describe('transformHeadingNode (deprecation Type -> AlertBox level)', () => {
 
     assert.equal(alert.name, 'AlertBox');
     assert.equal(levelAttr.value, 'danger');
+  });
+});
+
+describe('gatherChangeEntries', () => {
+  it('returns empty array when entry has no changes', () => {
+    assert.deepEqual(gatherChangeEntries({}), []);
+  });
+
+  it('collects lifecycle changes with formatted labels', () => {
+    const result = gatherChangeEntries({
+      added: ['v20.0.0', 'v18.0.0'],
+      deprecated: 'v22.0.0',
+    });
+
+    assert.equal(result.length, 2);
+    assert.deepEqual(result[0], {
+      versions: ['v20.0.0', 'v18.0.0'],
+      label: 'Added in: v20.0.0, v18.0.0',
+    });
+    assert.deepEqual(result[1], {
+      versions: ['v22.0.0'],
+      label: 'Deprecated in: v22.0.0',
+    });
+  });
+
+  it('extracts plain text labels from markdown descriptions', () => {
+    const result = gatherChangeEntries({
+      changes: [
+        {
+          version: 'v25.0.0',
+          description:
+            'Add `modifyPrototype` option to conditionally modify the prototype.',
+          'pr-url': 'https://github.com/nodejs/node/pull/123',
+        },
+      ],
+    });
+
+    assert.equal(result.length, 1);
+    assert.equal(
+      result[0].label,
+      'Add `modifyPrototype` option to conditionally modify the prototype.'
+    );
+    assert.equal(result[0].url, 'https://github.com/nodejs/node/pull/123');
+    assert.deepEqual(result[0].versions, ['v25.0.0']);
+  });
+
+  it('produces a string label, not an object (regression for [object Object])', () => {
+    const result = gatherChangeEntries({
+      changes: [
+        {
+          version: 'v1.0.0',
+          description: 'Some **bold** and _italic_ text.',
+        },
+      ],
+    });
+
+    assert.equal(typeof result[0].label, 'string');
+    assert.equal(result[0].label, 'Some **bold** and _italic_ text.');
+  });
+
+  it('combines lifecycle changes and explicit changes', () => {
+    const result = gatherChangeEntries({
+      added: 'v20.0.0',
+      changes: [
+        {
+          version: 'v21.0.0',
+          description: 'Added new feature.',
+          'pr-url': 'https://example.com/pr/1',
+        },
+      ],
+    });
+
+    assert.equal(result.length, 2);
+    assert.equal(result[0].label, 'Added in: v20.0.0');
+    assert.equal(result[1].label, 'Added new feature.');
   });
 });

--- a/packages/react/src/jsx-ast/utils/buildContent.mjs
+++ b/packages/react/src/jsx-ast/utils/buildContent.mjs
@@ -8,6 +8,7 @@ import {
 } from '@doc-kit/core/utils/configuration/templates.mjs';
 import { omitKeys } from '@doc-kit/core/utils/misc.mjs';
 import { UNIST } from '@doc-kit/core/utils/queries/index.mjs';
+import { transformNodesToString } from '@doc-kit/core/utils/unist.mjs';
 import { h as createElement } from 'hastscript';
 import { slice } from 'mdast-util-slice-markdown';
 import readingTime from 'reading-time';
@@ -44,14 +45,10 @@ import {
  * @param {string} markdown - The markdown string to convert.
  * @returns {string} The plain text representation.
  */
-const toPlainText = markdown => {
-  const tree = unified().use(remarkParse).parse(markdown);
-  let text = '';
-  visit(tree, ['text', 'inlineCode'], node => {
-    text += node.value || '';
-  });
-  return text.trim();
-};
+const toPlainText = markdown =>
+  transformNodesToString(
+    unified().use(remarkParse).parse(markdown).children
+  ).trim();
 
 /**
  * Processes lifecycle and change history data into a sorted array of change entries.

--- a/packages/react/src/jsx-ast/utils/buildContent.mjs
+++ b/packages/react/src/jsx-ast/utils/buildContent.mjs
@@ -11,6 +11,8 @@ import { UNIST } from '@doc-kit/core/utils/queries/index.mjs';
 import { h as createElement } from 'hastscript';
 import { slice } from 'mdast-util-slice-markdown';
 import readingTime from 'reading-time';
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
 import { u as createTree } from 'unist-builder';
 import { SKIP, visit } from 'unist-util-visit';
 
@@ -36,6 +38,22 @@ import {
 } from './signature.mjs';
 
 /**
+ * Converts a markdown string to plain text by parsing it and extracting
+ * text and inline code values.
+ *
+ * @param {string} markdown - The markdown string to convert.
+ * @returns {string} The plain text representation.
+ */
+const toPlainText = markdown => {
+  const tree = unified().use(remarkParse).parse(markdown);
+  let text = '';
+  visit(tree, ['text', 'inlineCode'], node => {
+    text += node.value || '';
+  });
+  return text.trim();
+};
+
+/**
  * Processes lifecycle and change history data into a sorted array of change entries.
  * @param {import('@doc-kit/core/generators/metadata/types').MetadataEntry} entry - The metadata entry
  */
@@ -48,11 +66,10 @@ export const gatherChangeEntries = entry => {
       label: `${label}: ${enforceArray(entry[field]).join(', ')}`,
     }));
 
-  // Explicit changes with parsed JSX labels
+  // Explicit changes with plain-text labels extracted from markdown
   const explicitChanges = (entry.changes || []).map(change => ({
     versions: enforceArray(change.version),
-    label: remark().runSync(remark().parse(change.description)).body[0]
-      .expression,
+    label: toPlainText(change.description),
     url: change['pr-url'],
   }));
 


### PR DESCRIPTION
 <!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
<img width="1333" height="823" alt="image" src="https://github.com/user-attachments/assets/0c038303-e4b4-4a20-979a-622ef102873f" />

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format:check` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
