### PR TITLE
fix(jsx-ast): hide redundant headers and badges for overloaded methods

### DIFF
--- a/packages/react/src/jsx-ast/utils/__tests__/buildContent.test.mjs
+++ b/packages/react/src/jsx-ast/utils/__tests__/buildContent.test.mjs
@@ -3,7 +3,10 @@ import { describe, it } from 'node:test';
 
 import { setConfig } from '@doc-kit/core/utils/configuration/index.mjs';
 
-import { transformHeadingNode } from '../buildContent.mjs';
+import {
+  transformHeadingNode,
+  createHeadingElement,
+} from '../buildContent.mjs';
 
 const heading = {
   type: 'heading',
@@ -65,5 +68,35 @@ describe('transformHeadingNode (deprecation Type -> AlertBox level)', () => {
 
     assert.equal(alert.name, 'AlertBox');
     assert.equal(levelAttr.value, 'danger');
+  });
+});
+
+describe('createHeadingElement (Overloads Layout)', () => {
+  it('returns a hidden span for subsequent overloads to prevent UI noise', () => {
+    const content = {
+      depth: 3,
+      data: { type: 'method', slug: 'factorizemodule-1', isOverload: true },
+    };
+
+    const result = createHeadingElement(content, null);
+
+    assert.equal(result.type, 'element');
+    assert.equal(result.tagName, 'span');
+    assert.equal(result.properties.id, 'factorizemodule-1');
+    assert.equal(result.properties.style, 'display: none;');
+  });
+
+  it('returns a full heading element for normal methods (non-overloads)', () => {
+    const content = {
+      depth: 3,
+      data: { type: 'method', slug: 'factorizemodule' },
+    };
+
+    const result = createHeadingElement(content, null);
+
+    assert.equal(result.tagName, 'div');
+    const h3 = result.children.find(child => child.tagName === 'h3');
+    assert.ok(h3);
+    assert.equal(h3.properties.id, 'factorizemodule');
   });
 });

--- a/packages/react/src/jsx-ast/utils/buildContent.mjs
+++ b/packages/react/src/jsx-ast/utils/buildContent.mjs
@@ -132,7 +132,11 @@ export const extractHeadingContent = content => {
  * @param {import('unist').Node|null} changeElement - The change history element, if available
  */
 export const createHeadingElement = (content, changeElement) => {
-  const { type, slug } = content.data;
+  const { type, slug, isOverload } = content.data;
+
+  if (isOverload) {
+    return createElement('span', { id: slug, style: 'display: none;' });
+  }
 
   let headingContent = extractHeadingContent(content);
 


### PR DESCRIPTION
## Description

This PR removes the heading from the overloads function; just keep one for the first function that appears like grouping them.

## Validation

### Before:
<img width="850" height="921" alt="image" src="https://github.com/user-attachments/assets/15fffe30-face-4cf6-b328-c16ee465756b" />

### After:
<img width="850" height="857" alt="image" src="https://github.com/user-attachments/assets/c46ad95e-7f1e-4cae-907c-b4e84137da29" />

## Related Issues

None

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `pnpm test` and all tests passed.
- [X] I have check code formatting with `pnpm run format:check` & `pnpm run lint`.
- [X] I've covered new added functionality with unit tests if necessary.
