### PR TITLE
fix: export MetadataEntry types from @doc-kit/core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,14 @@
     "./ast-js": "./src/generators/ast-js/index.mjs",
     "./json-simple": "./src/generators/json-simple/index.mjs",
     "./metadata": "./src/generators/metadata/index.mjs",
+    "./metadata/types": {
+      "types": "./src/generators/metadata/types.d.ts",
+      "default": "./src/generators/metadata/types.d.ts"
+    },
+    "./generators/metadata/types": {
+      "types": "./src/generators/metadata/types.d.ts",
+      "default": "./src/generators/metadata/types.d.ts"
+    },
     "./package.json": "./package.json",
     "./shiki.config.mjs": "./shiki.config.mjs",
     "./src/*": "./src/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,18 +21,13 @@
     "./ast-js": "./src/generators/ast-js/index.mjs",
     "./json-simple": "./src/generators/json-simple/index.mjs",
     "./metadata": "./src/generators/metadata/index.mjs",
-    "./metadata/types": {
-      "types": "./src/generators/metadata/types.d.ts",
-      "default": "./src/generators/metadata/types.d.ts"
-    },
-    "./generators/metadata/types": {
-      "types": "./src/generators/metadata/types.d.ts",
-      "default": "./src/generators/metadata/types.d.ts"
-    },
     "./package.json": "./package.json",
     "./shiki.config.mjs": "./shiki.config.mjs",
     "./src/*": "./src/*",
-    "./*": "./src/*"
+    "./*": [
+      "./src/*",
+      "./src/*.d.ts"
+    ]
   },
   "files": [
     "src",


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Add explicit exports map entries for the metadata types subpaths (`./metadata/types` and `./generators/metadata/types`) pointing to `types.d.ts`. Previously, these paths only resolved through the `./*` wildcard, which fails under bundler module resolution since an extensionless specifier can't resolve to a `.d.ts` file. This caused JSDoc `import('@doc-kit/core/generators/metadata/types')` type annotations across the react/node packages to silently fail, leaving params typed as `any`.

<img width="1400" height="922" alt="image" src="https://github.com/user-attachments/assets/baf242cf-355b-40ad-b3f3-f04a7cf151a3" />

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format:check` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
