### PR TITLE
fix(margin): margin is controlled by `ui-components`, not us

### DIFF
--- a/packages/react/src/html/ui/index.css
+++ b/packages/react/src/html/ui/index.css
@@ -110,6 +110,7 @@ main {
     > h5,
     > h6 {
       flex: 1;
+      margin-top: 0;
       margin-bottom: 8px;
       overflow-wrap: anywhere;
       word-break: break-word;


### PR DESCRIPTION
When building doc-kit using a brand new version of ui-components, the margin may be off by a few pixels, this rectifies that