### PR TITLE
refactor(core): replace parent-relative imports with `#` package imports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,22 +31,13 @@
     ]
   },
   "imports": {
-    "#generators/*": [
-      "./src/generators/*",
-      "./src/generators/*.d.ts"
-    ],
-    "#logger/*": [
-      "./src/logger/*",
-      "./src/logger/*.d.ts"
-    ],
+    "#generators/*": "./src/generators/*",
+    "#logger/*": "./src/logger/*",
     "#parsers/*": [
       "./src/parsers/*",
       "./src/parsers/*.d.ts"
     ],
-    "#utils/*": [
-      "./src/utils/*",
-      "./src/utils/*.d.ts"
-    ]
+    "#utils/*": "./src/utils/*"
   },
   "files": [
     "src",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,24 @@
       "./src/*.d.ts"
     ]
   },
+  "imports": {
+    "#generators/*": [
+      "./src/generators/*",
+      "./src/generators/*.d.ts"
+    ],
+    "#logger/*": [
+      "./src/logger/*",
+      "./src/logger/*.d.ts"
+    ],
+    "#parsers/*": [
+      "./src/parsers/*",
+      "./src/parsers/*.d.ts"
+    ],
+    "#utils/*": [
+      "./src/utils/*",
+      "./src/utils/*.d.ts"
+    ]
+  },
   "files": [
     "src",
     "!src/**/*.test.mjs",

--- a/packages/core/src/generators/ast-js/generate.mjs
+++ b/packages/core/src/generators/ast-js/generate.mjs
@@ -6,7 +6,7 @@ import { extname } from 'node:path';
 import { parse } from 'acorn';
 import { globSync } from 'tinyglobby';
 
-import getConfig from '../../utils/configuration/index.mjs';
+import getConfig from '#utils/configuration/index.mjs';
 
 /**
  * Process a chunk of JavaScript files in a worker thread.

--- a/packages/core/src/generators/ast/generate.mjs
+++ b/packages/core/src/generators/ast/generate.mjs
@@ -7,11 +7,12 @@ import globParent from 'glob-parent';
 import { globSync } from 'tinyglobby';
 import { parse as parseYaml } from 'yaml';
 
+import getConfig from '#utils/configuration/index.mjs';
+import { withExt } from '#utils/file.mjs';
+import { QUERIES } from '#utils/queries/index.mjs';
+import { getRemark as remark, getRemarkMdx } from '#utils/remark.mjs';
+
 import { STABILITY_INDEX_URL } from './constants.mjs';
-import getConfig from '../../utils/configuration/index.mjs';
-import { withExt } from '../../utils/file.mjs';
-import { QUERIES } from '../../utils/queries/index.mjs';
-import { getRemark as remark, getRemarkMdx } from '../../utils/remark.mjs';
 
 /**
  * Determines whether a file should be parsed as MDX. A `.mdx` extension opts in

--- a/packages/core/src/generators/json-simple/generate.mjs
+++ b/packages/core/src/generators/json-simple/generate.mjs
@@ -4,9 +4,9 @@ import { join } from 'node:path';
 
 import { remove } from 'unist-util-remove';
 
-import getConfig from '../../utils/configuration/index.mjs';
-import { writeFile } from '../../utils/file.mjs';
-import { UNIST } from '../../utils/queries/index.mjs';
+import getConfig from '#utils/configuration/index.mjs';
+import { writeFile } from '#utils/file.mjs';
+import { UNIST } from '#utils/queries/index.mjs';
 
 /**
  * Generates the simplified JSON version of the API docs

--- a/packages/core/src/generators/metadata/generate.mjs
+++ b/packages/core/src/generators/metadata/generate.mjs
@@ -1,8 +1,9 @@
 'use strict';
 
+import getConfig from '#utils/configuration/index.mjs';
+import { loadFromURL } from '#utils/loaders.mjs';
+
 import { parseApiDoc } from './utils/parse.mjs';
-import getConfig from '../../utils/configuration/index.mjs';
-import { loadFromURL } from '../../utils/loaders.mjs';
 
 /**
  * Process a chunk of API doc files in a worker thread.

--- a/packages/core/src/generators/metadata/utils/parse.mjs
+++ b/packages/core/src/generators/metadata/utils/parse.mjs
@@ -9,6 +9,15 @@ import { remove } from 'unist-util-remove';
 import { selectAll } from 'unist-util-select';
 import { SKIP, visit } from 'unist-util-visit';
 
+import {
+  DEPRECATION_HEADING_REGEX,
+  IGNORE_STABILITY_STEMS,
+} from '#generators/metadata/constants.mjs';
+import { UNIST } from '#utils/queries/index.mjs';
+import { getRemark as remark } from '#utils/remark.mjs';
+import { relative } from '#utils/url.mjs';
+
+import { resolveTypeAnnotations } from './resolveTypes.mjs';
 import createNodeSlugger from './slugger.mjs';
 import { transformNodeToHeading } from './transformers.mjs';
 import {
@@ -18,14 +27,6 @@ import {
   visitTextWithUnixManualNode,
   visitYAML,
 } from './visitors.mjs';
-import { UNIST } from '../../../utils/queries/index.mjs';
-import { getRemark as remark } from '../../../utils/remark.mjs';
-import { relative } from '../../../utils/url.mjs';
-import {
-  DEPRECATION_HEADING_REGEX,
-  IGNORE_STABILITY_STEMS,
-} from '../constants.mjs';
-import { resolveTypeAnnotations } from './resolveTypes.mjs';
 
 /**
  * This generator generates a flattened list of metadata entries from a API doc

--- a/packages/core/src/generators/metadata/utils/resolveTypes.mjs
+++ b/packages/core/src/generators/metadata/utils/resolveTypes.mjs
@@ -1,9 +1,10 @@
 import { parseSync } from '@swc/wasm';
 import { visit } from 'unist-util-visit';
 
+import logger from '#logger/index.mjs';
+import { walk } from '#utils/swc.mjs';
+
 import { lookupTypeName, resolveTypeReference } from './transformers.mjs';
-import logger from '../../../logger/index.mjs';
-import { walk } from '../../../utils/swc.mjs';
 
 // `null` is a keyword kind in SWC, unlike most parsers which treat it as a literal type
 const KEYWORDS = new Set([

--- a/packages/core/src/generators/metadata/utils/slugger.mjs
+++ b/packages/core/src/generators/metadata/utils/slugger.mjs
@@ -2,7 +2,7 @@
 
 import GitHubSlugger, { slug as defaultSlugFn } from 'github-slugger';
 
-import { DOC_API_SLUGS_REPLACEMENTS } from '../constants.mjs';
+import { DOC_API_SLUGS_REPLACEMENTS } from '#generators/metadata/constants.mjs';
 
 /**
  * Creates a modified version of the GitHub Slugger

--- a/packages/core/src/generators/metadata/utils/transformers.mjs
+++ b/packages/core/src/generators/metadata/utils/transformers.mjs
@@ -2,11 +2,12 @@ import {
   DOC_MAN_BASE_URL,
   DOC_API_HEADING_TYPES,
   MODULE_QUALIFIED_NAME,
-} from '../constants.mjs';
+} from '#generators/metadata/constants.mjs';
+import BUILTIN_TYPE_MAP from '#generators/metadata/maps/builtin.json' with { type: 'json' };
+import MDN_TYPE_MAP from '#generators/metadata/maps/mdn.json' with { type: 'json' };
+import { transformNodesToString } from '#utils/unist.mjs';
+
 import { slug } from './slugger.mjs';
-import { transformNodesToString } from '../../../utils/unist.mjs';
-import BUILTIN_TYPE_MAP from '../maps/builtin.json' with { type: 'json' };
-import MDN_TYPE_MAP from '../maps/mdn.json' with { type: 'json' };
 
 /**
  * @param {string} text The inner text

--- a/packages/core/src/generators/metadata/utils/visitors.mjs
+++ b/packages/core/src/generators/metadata/utils/visitors.mjs
@@ -2,11 +2,12 @@
 
 import { SKIP } from 'unist-util-visit';
 
+import { QUERIES } from '#utils/queries/index.mjs';
+import { getRemark as remark } from '#utils/remark.mjs';
+import { transformNodesToString } from '#utils/unist.mjs';
+
 import { transformUnixManualToLink } from './transformers.mjs';
 import { extractYamlContent, parseYAMLIntoMetadata } from './yaml.mjs';
-import { QUERIES } from '../../../utils/queries/index.mjs';
-import { getRemark as remark } from '../../../utils/remark.mjs';
-import { transformNodesToString } from '../../../utils/unist.mjs';
 
 /**
  * Updates a Markdown link into a HTML link for API docs

--- a/packages/core/src/generators/metadata/utils/yaml.mjs
+++ b/packages/core/src/generators/metadata/utils/yaml.mjs
@@ -2,7 +2,7 @@
 
 import yaml from 'yaml';
 
-import { QUERIES } from '../../../utils/queries/index.mjs';
+import { QUERIES } from '#utils/queries/index.mjs';
 
 /**
  * Extracts raw YAML content from a node

--- a/packages/core/src/logger/transports/console.mjs
+++ b/packages/core/src/logger/transports/console.mjs
@@ -2,8 +2,8 @@
 
 import { styleText } from 'node:util';
 
-import { prettifyLevel } from '../utils/colors.mjs';
-import { prettifyTimestamp } from '../utils/time.mjs';
+import { prettifyLevel } from '#logger/utils/colors.mjs';
+import { prettifyTimestamp } from '#logger/utils/time.mjs';
 
 /**
  * Logs a formatted message to stdout for human-friendly CLI output.

--- a/packages/core/src/logger/transports/github.mjs
+++ b/packages/core/src/logger/transports/github.mjs
@@ -2,9 +2,9 @@
 
 import { debug, notice, warning, error } from '@actions/core';
 
-import { LogLevel } from '../constants.mjs';
-import { prettifyLevel } from '../utils/colors.mjs';
-import { prettifyTimestamp } from '../utils/time.mjs';
+import { LogLevel } from '#logger/constants.mjs';
+import { prettifyLevel } from '#logger/utils/colors.mjs';
+import { prettifyTimestamp } from '#logger/utils/time.mjs';
 
 const actions = {
   [LogLevel.debug]: debug,

--- a/packages/core/src/logger/utils/colors.mjs
+++ b/packages/core/src/logger/utils/colors.mjs
@@ -2,7 +2,7 @@
 
 import { styleText } from 'node:util';
 
-import { levelTags, levelToColorMap } from '../constants.mjs';
+import { levelTags, levelToColorMap } from '#logger/constants.mjs';
 
 /**
  * Returns a styled, uppercase log level tag for CLI output with color mapping

--- a/packages/core/src/parsers/markdown.mjs
+++ b/packages/core/src/parsers/markdown.mjs
@@ -2,7 +2,7 @@
 
 import { coerce } from 'semver';
 
-import { loadFromURL } from '../utils/loaders.mjs';
+import { loadFromURL } from '#utils/loaders.mjs';
 
 // A ReGeX for retrieving Node.js version headers from the CHANGELOG.md
 const NODE_VERSIONS_REGEX = /\* \[Node\.js ([0-9.]+)\]\S+ (.*)\r?\n/g;

--- a/packages/core/src/threading/chunk-worker.mjs
+++ b/packages/core/src/threading/chunk-worker.mjs
@@ -1,5 +1,5 @@
-import { loadGenerator } from '../generators/loader.mjs';
-import { setConfig } from '../utils/configuration/index.mjs';
+import { loadGenerator } from '#generators/loader.mjs';
+import { setConfig } from '#utils/configuration/index.mjs';
 
 /**
  * Processes a chunk of items using the specified generator's processChunk method.

--- a/packages/core/src/threading/index.mjs
+++ b/packages/core/src/threading/index.mjs
@@ -1,6 +1,6 @@
 import Piscina from 'piscina';
 
-import logger from '../logger/index.mjs';
+import logger from '#logger/index.mjs';
 
 const poolLogger = logger.child('WorkerPool');
 

--- a/packages/core/src/threading/parallel.mjs
+++ b/packages/core/src/threading/parallel.mjs
@@ -1,6 +1,6 @@
 'use strict';
 
-import logger from '../logger/index.mjs';
+import logger from '#logger/index.mjs';
 
 const parallelLogger = logger.child('parallel');
 

--- a/packages/core/src/utils/configuration/index.mjs
+++ b/packages/core/src/utils/configuration/index.mjs
@@ -11,12 +11,12 @@ import { coerce } from 'semver';
 import {
   loadGenerators,
   resolveGeneratorSpecifier,
-} from '../../generators/loader.mjs';
-import logger from '../../logger/index.mjs';
-import { parseChangelog, parseIndex } from '../../parsers/markdown.mjs';
-import { enforceArray } from '../array.mjs';
-import { leftHandAssign } from '../generators.mjs';
-import { deepMerge } from '../misc.mjs';
+} from '#generators/loader.mjs';
+import logger from '#logger/index.mjs';
+import { parseChangelog, parseIndex } from '#parsers/markdown.mjs';
+import { enforceArray } from '#utils/array.mjs';
+import { leftHandAssign } from '#utils/generators.mjs';
+import { deepMerge } from '#utils/misc.mjs';
 
 const configExplorer = cosmiconfig('doc-kit');
 

--- a/packages/core/src/utils/configuration/types.d.ts
+++ b/packages/core/src/utils/configuration/types.d.ts
@@ -1,5 +1,5 @@
 import type { SemVer } from 'semver';
-import type { ReleaseEntry } from '../../parsers/types';
+import type { ReleaseEntry } from '#parsers/types';
 
 export type Configuration = {
   global: GlobalConfiguration;

--- a/packages/core/src/utils/queries/index.mjs
+++ b/packages/core/src/utils/queries/index.mjs
@@ -1,6 +1,7 @@
 'use strict';
 
-import { transformNodesToString } from '../unist.mjs';
+import { transformNodesToString } from '#utils/unist.mjs';
+
 import { isTypedListItem, isTypedList } from './utils.mjs';
 
 // This defines the actual REGEX Queries

--- a/packages/core/src/utils/signature/parseList.mjs
+++ b/packages/core/src/utils/signature/parseList.mjs
@@ -1,12 +1,13 @@
+import { leftHandAssign } from '#utils/generators.mjs';
+import { QUERIES, UNIST } from '#utils/queries/index.mjs';
+import { transformNodesToString } from '#utils/unist.mjs';
+
 import {
   DEFAULT_EXPRESSION,
   LEADING_HYPHEN,
   NAME_EXPRESSION,
 } from './constants.mjs';
 import parseSignature from './parseSignature.mjs';
-import { leftHandAssign } from '../generators.mjs';
-import { QUERIES, UNIST } from '../queries/index.mjs';
-import { transformNodesToString } from '../unist.mjs';
 
 /**
  * Extracts and removes a specific pattern from a text string while storing the result in a key of the `current` object.

--- a/packages/core/src/utils/type-annotations/hast.mjs
+++ b/packages/core/src/utils/type-annotations/hast.mjs
@@ -1,6 +1,6 @@
 'use strict';
 
-import { highlighter } from '../highlighter.mjs';
+import { highlighter } from '#utils/highlighter.mjs';
 
 const [lightTheme, darkTheme] = highlighter.shiki.getLoadedThemes();
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
refer to https://beta.docs.nodejs.org/packages#subpath-imports
<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format:check` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
